### PR TITLE
Support ARM for local development

### DIFF
--- a/.github/scripts/prepare-ci.sh
+++ b/.github/scripts/prepare-ci.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+cp .env.example .env

--- a/.github/workflows/image-builds.yml
+++ b/.github/workflows/image-builds.yml
@@ -1,0 +1,14 @@
+name: Docker images build
+on:
+  push:
+  pull_request:
+    branches: [master]
+
+jobs:
+  image-build:
+    name: Test Images Build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: ./.github/scripts/prepare-ci.sh
+      - run: docker compose build

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,8 +16,16 @@ ENV PYTHONUNBUFFERED=1
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
     build-essential \
+    # mysqlclient dependencies
     pkg-config \
-    default-libmysqlclient-dev && \
+    default-libmysqlclient-dev \
+    # TODO: Remove libheif dependencies. They are only necssary because
+    # pyheif doesn't yet release an ARM compatible wheel. Once a compatible
+    # wheel is published on pypi, these dependencies should be removed from
+    # both the builder and final images.
+    libheif-dev \
+    # end libheif dependencies
+    && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
@@ -69,7 +77,10 @@ RUN apt-get update && \
     pkg-config \
     default-libmysqlclient-dev \
     cron \
-    nano && \
+    nano \
+    # libheif dependencies
+    libheif-dev \
+    && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -64,7 +64,7 @@ WORKDIR $APP_HOME
 # install dependencies
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
-    netcat \
+    netcat-traditional \
     build-essential \
     pkg-config \
     default-libmysqlclient-dev \

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 ###########
 
 # pull official base image
-FROM python:3.11.4-slim-buster AS builder
+FROM python:3.11.9 AS builder
 
 # set work directory
 WORKDIR /usr/src/app
@@ -40,7 +40,7 @@ RUN pip wheel --no-cache-dir --no-deps --wheel-dir /usr/src/app/wheels -r requir
 #########
 
 # pull official base image
-FROM python:3.11.4-slim-buster
+FROM python:3.11.9-slim
 
 # create directory for the app user
 RUN mkdir -p /home/app


### PR DESCRIPTION
I use a MacOS laptop that runs an ARM architecture and was unable to run and build this project locally. I traced the problem as follows:

1. `pyheif` (a dependency of `heif-image-plugin`) fails the docker build during compilation due to missing system dependencies.
1. `pyheif` attempts to build a wheel instead of using the version on pypi because the package doesn't publish an ARM compatible version
1. The wheel still fails to build after installing the necessary dependency `libheif-dev`, as the version published for Ubuntu Bullseye (OS version currently used) is too old.

This PR resolves this issue. The reviewer is encouraged to review commit by commit:

- f89d7f373e2c80a65ee2c942d67112cec6a668ea and 3979357f593b5ad51bf08bfb00fa8c3de910a52a: Upgrade to latest OS version to pull in more recent `libheif` version and address packages whose names changed between OS versions
- 6bbd8e0027f8598da5fe6d24718dd062bb126c66: Add `libheif-dev` package
- 1acd1f5eb1a7cd0113b1263dfdea2e492cee1403: Add CI step that builds the docker images using Github Actions (which uses x86) to ensure this change didn't break compatibility. See [this CI run](https://github.com/jamescurtin/fishauctions/actions/runs/10646257461/job/29512904382) from my fork to demonstrate that CI passes.