### PR TITLE
Update dependencies

### DIFF
--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -10,7 +10,7 @@ env:
   DEBUG: True
   SECRET_KEY: abcde
   ALLOWED_HOST_1: localhost
-  ALLOWED_HOST_2: 
+  ALLOWED_HOST_2:
   ALLOWED_HOST_3: 127.0.0.1
   DATABASE_ENGINE: django.db.backends.mysql
   DATABASE_NAME: auctions
@@ -21,7 +21,7 @@ env:
   BASE_URL: https://auction.fish
   EMAIL_USE_TLS: True
   EMAIL_HOST: smtp.example.com
-  EMAIL_PORT: 
+  EMAIL_PORT:
   EMAIL_HOST_USER: user@example.com
   EMAIL_HOST_PASSWORD: 123456
   DEFAULT_FROM_EMAIL: Notifications
@@ -46,7 +46,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [3.9]
+        python-version: [3.11]
 
     steps:
     - uses: actions/checkout@v4

--- a/auctions/static/admin/css/unusable_password_field.css
+++ b/auctions/static/admin/css/unusable_password_field.css
@@ -1,0 +1,19 @@
+/* Hide warnings fields if usable password is selected */
+form:has(#id_usable_password input[value="true"]:checked) .messagelist {
+    display: none;
+}
+
+/* Hide password fields if unusable password is selected */
+form:has(#id_usable_password input[value="false"]:checked) .field-password1,
+form:has(#id_usable_password input[value="false"]:checked) .field-password2 {
+    display: none;
+}
+
+/* Select appropriate submit button */
+form:has(#id_usable_password input[value="true"]:checked) input[type="submit"].unset-password {
+    display: none;
+}
+
+form:has(#id_usable_password input[value="false"]:checked) input[type="submit"].set-password {
+    display: none;
+}

--- a/auctions/static/admin/js/unusable_password_field.js
+++ b/auctions/static/admin/js/unusable_password_field.js
@@ -1,0 +1,29 @@
+"use strict";
+// Fallback JS for browsers which do not support :has selector used in
+// admin/css/unusable_password_fields.css
+// Remove file once all supported browsers support :has selector
+try {
+    // If browser does not support :has selector this will raise an error
+    document.querySelector("form:has(input)");
+} catch (error) {
+    console.log("Defaulting to javascript for usable password form management: " + error);
+    // JS replacement for unsupported :has selector
+    document.querySelectorAll('input[name="usable_password"]').forEach(option => {
+        option.addEventListener('change', function() {
+            const usablePassword = (this.value === "true" ? this.checked : !this.checked);
+            const submit1 = document.querySelector('input[type="submit"].set-password');
+            const submit2 = document.querySelector('input[type="submit"].unset-password');
+            const messages = document.querySelector('#id_unusable_warning');
+            document.getElementById('id_password1').closest('.form-row').hidden = !usablePassword;
+            document.getElementById('id_password2').closest('.form-row').hidden = !usablePassword;
+            if (messages) {
+                messages.hidden = usablePassword;
+            }
+            if (submit1 && submit2) {
+                submit1.hidden = !usablePassword;
+                submit2.hidden = usablePassword;
+            }
+        });
+        option.dispatchEvent(new Event('change'));
+    });
+}

--- a/fishauctions/settings.py
+++ b/fishauctions/settings.py
@@ -287,6 +287,7 @@ THUMBNAIL_ALIASES = {
         #'lot_full': {'size': (600, 600), 'crop': False},
     },
 }
+THUMBNAIL_DEFAULT_STORAGE_ALIAS = "default"
 
 SECURE_REFERRER_POLICY= "strict-origin-when-cross-origin"
 

--- a/requirements.in
+++ b/requirements.in
@@ -31,7 +31,7 @@ django_htmx
 django_debug_toolbar
 django-recaptcha
 django-chartjs
-easy-thumbnails
+easy-thumbnails>2.8.5
 hyperlink
 idna
 incremental

--- a/requirements.txt
+++ b/requirements.txt
@@ -143,7 +143,7 @@ django-ses[events]==4.1.0
     # via -r ./requirements.in
 django-tables2==2.7.0
     # via -r ./requirements.in
-easy-thumbnails==2.8.5
+easy-thumbnails==2.9
     # via -r ./requirements.in
 gunicorn==22.0.0
     # via -r ./requirements.in

--- a/requirements.txt
+++ b/requirements.txt
@@ -37,7 +37,7 @@ bleach[css]==6.1.0
     #   django-post-office
 boto3==1.35.0
     # via django-ses
-botocore>=1.35.0
+botocore==1.35.10
     # via
     #   boto3
     #   s3transfer
@@ -83,7 +83,7 @@ defusedxml==0.7.1
     # via
     #   -r ./requirements.in
     #   python3-openid
-django>=4.2.14,<5.1
+django==5.1
     # via
     #   -r ./requirements.in
     #   channels
@@ -135,7 +135,7 @@ django-markdownfield==0.11.0
     # via -r ./requirements.in
 django-post-office==3.9.0
     # via -r ./requirements.in
-django-qr-code>=4.0.1
+django-qr-code==4.1.0
     # via -r ./requirements.in
 django-recaptcha==4.0.0
     # via -r ./requirements.in
@@ -304,7 +304,7 @@ ua-parser==0.18.0
     # via
     #   -r ./requirements.in
     #   user-agents
-urllib3>=1.21.1
+urllib3==2.2.2
     # via
     #   -r ./requirements.in
     #   botocore


### PR DESCRIPTION
As part of drafting a different PR, I ran `pip-compile` and noticed that it resulted in some packages being upgraded.

1. The first commit is the auto-generated change resulting from re-running `pip-compile ./requirements.in`.
1. Upgrading Django resulted in the auto-generation of some login-related frontend code, which is committed in the second commit.
1. One package, `easy-thumbnails`, had an incompatibility with Django 5.1 (documented [here](https://github.com/SmileyChris/easy-thumbnails/issues/641)), which is resolved in the third commit by setting a minimum version for the package as well as explicitly setting the storage backend.

While I have confirmed that the app starts up successfully, I do not yet have a more robust testing strategy for making changes like this--in particular given that the Django upgrade was across a major version. I figured I'd start by proposing this change in the spirit of keeping dependences up-to-date--but if this seems risky given the current light test coverage, I can re-work this and just pin `django<5` in `requirements.in`.