### PR TITLE
Add VSCode dev container

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,34 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/docker-existing-docker-compose
+{
+	"name": "fishauctions-remote",
+	"dockerComposeFile": [
+		"docker-compose.yml"
+	],
+	"service": "dev",
+	"workspaceFolder": "/workspace",
+	// Features to add to the dev container. More info: https://containers.dev/features.
+	"features": {
+		"ghcr.io/devcontainers/features/common-utils:2": {},
+		"ghcr.io/mikaello/devcontainer-features/modern-shell-utils:1": {},
+		"ghcr.io/devcontainers/features/docker-in-docker:2.11.0": {},
+		"ghcr.io/devcontainers/features/git:1": {},
+		"ghcr.io/devcontainers/features/python:1": {}
+
+	},
+	"remoteEnv": { "LOCAL_WORKSPACE_FOLDER": "${localWorkspaceFolder}" },
+	"customizations": {
+		"vscode": {
+			"extensions": [
+				"charliermarsh.ruff",
+				"streetsidesoftware.code-spell-checker",
+				"njpwerner.autodocstring",
+				"eamodio.gitlens",
+				"ms-python.python",
+				"ms-python.vscode-pylance",
+				"ms-python.debugpy",
+				"github.vscode-github-actions"
+			]
+		}
+	}
+}

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,0 +1,9 @@
+services:
+  dev:
+    build:
+      context: ../
+      dockerfile: Dockerfile
+      target: dev
+    volumes:
+      - ${LOCAL_WORKSPACE_FOLDER:-../}:/workspace
+    command: sleep infinity

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for more information:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+# https://containers.dev/guide/dependabot
+
+version: 2
+updates:
+ - package-ecosystem: "devcontainers"
+   directory: "/"
+   schedule:
+     interval: weekly

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,9 +6,6 @@
     "files.insertFinalNewline": true,
     "files.trimFinalNewlines": true,
     "files.trimTrailingWhitespace": true,
-    "python.linting.pylintEnabled": false,
-    "python.linting.banditEnabled": true,
-    "python.linting.enabled": true,
     "ruff.enable": true,
     "ruff.codeAction.fixViolation": {
         "enable": true

--- a/Dockerfile
+++ b/Dockerfile
@@ -51,6 +51,16 @@ FROM python:3.11.9-slim AS test
 COPY ./requirements-test.txt .
 RUN pip install -r requirements-test.txt
 
+
+#########
+# Dev Container #
+#########
+
+
+FROM builder AS dev
+COPY ./requirements*.txt .
+RUN pip install -r requirements*.txt
+
 #########
 # FINAL #
 #########

--- a/readme.md
+++ b/readme.md
@@ -70,3 +70,13 @@ To check if code is formatted properly *without* modifying any files on disk, ru
 
 #### Management commands
 Run these with docker exec after docker compose is up.  For example: `docker exec -it django python3 manage.py makemigrations`
+
+### Developing in VSCode
+
+This project is optimized for development in [Visual Studio Code](https://code.visualstudio.com/).
+If you are using VSCode, begin by installing the ["Remote Development" extension pack](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.vscode-remote-extensionpack), and make sure Docker is also installed.
+
+Working in a VSCode development container will ensure that all project dependencies are installed--aiding in running the Python language server, IDE auto-completion, running tests automatically, etc.
+
+To begin, follow the VS Code prompt to `Reopen in Container`. The first time running this command will take a while as the remote development container is built.
+You can also open this project in a remote container by opening the command palette (CMD+Shift+P), and navigate to `Dev Containers: Reopen in Container`.


### PR DESCRIPTION
Title says it all.

In order to get the IDE's language server working properly, you need to install all project dependencies. Given that the project is already Dockerized, we can have VSCode run inside a container. That means the IDE is always running with the same version of python and project dependencies that are used in production without needing to install them locally and keep them in sync.