### PR TITLE
Enable additional lints

### DIFF
--- a/auctions/filters.py
+++ b/auctions/filters.py
@@ -415,7 +415,7 @@ class LotFilter(django_filters.FilterSet):
             ).distinct()
         else:
             self.possibleAuctions = self.possibleAuctions.filter(specialAuctions)
-        auction_choices = list((o.slug, o.title) for o in self.possibleAuctions)
+        auction_choices = [(o.slug, o.title) for o in self.possibleAuctions]
         super().__init__(*args, **kwargs)  # this must go above filters
         self.filters["auction"].extra["choices"] = [
             {"no_auction": "noAuction", "No auction": "title"}
@@ -449,7 +449,7 @@ class LotFilter(django_filters.FilterSet):
     )
 
     def ships_choices(self):
-        choices = list((o.pk, o.name) for o in Location.objects.all().order_by("name"))
+        choices = [(o.pk, o.name) for o in Location.objects.all().order_by("name")]
         return [{"local_only": "local", "Local pickup": "title"}] + choices
 
     def generate_attrs(placeholder="", tooltip=""):

--- a/auctions/filters.py
+++ b/auctions/filters.py
@@ -65,7 +65,7 @@ class AuctionTOSFilter(django_filters.FilterSet):
         """
 
         # sketchy users
-        pattern = re.compile("^sus|\ssus\s|\ssus$")
+        pattern = re.compile(r"^sus|\ssus\s|\ssus$")
         if pattern.search(value):
             value = pattern.sub("", value)
             qs = add_tos_info(qs)
@@ -182,7 +182,7 @@ class AuctionTOSFilter(django_filters.FilterSet):
 
         # Apply filters based on patterns
         for keyword, filter_data in invoice_patterns.items():
-            pattern = re.compile(f"^{keyword}|\s{keyword}\s|\s{keyword}$")
+            pattern = re.compile(rf"^{keyword}|\s{keyword}\s|\s{keyword}$")
             if pattern.search(value):
                 value = pattern.sub("", value)
                 qs = qs.filter(**filter_data)

--- a/auctions/forms.py
+++ b/auctions/forms.py
@@ -1357,7 +1357,7 @@ class PickupLocationForm(forms.ModelForm):
             auction=self.auction, is_admin=True
         ).order_by("name")
         self.fields["contact_person"].queryset = contact_queryset
-        self.fields["contact_person"].label_from_instance = lambda obj: "%s" % obj.name
+        self.fields["contact_person"].label_from_instance = lambda obj: f"{obj.name}"
         delete_button_html = ""
         if self.is_edit_form:
             delete_button_html = f"<a href='{reverse('delete_pickup', kwargs={'pk': self.pickup_location.pk})}' class='btn bg-danger ms-2 '>Delete this location</a>"

--- a/auctions/management/commands/info.py
+++ b/auctions/management/commands/info.py
@@ -10,7 +10,8 @@ def compare_model_instances(instance1, instance2):
     :return: Dictionary with field names as keys and tuples of (instance1 value, instance2 value) as values for differing fields.
     """
     if type(instance1) is not type(instance2):
-        raise ValueError("Instances are not of the same model.")
+        msg = "Instances are not of the same model."
+        raise ValueError(msg)
 
     differences = {}
     for field in instance1._meta.fields:

--- a/auctions/management/commands/sendnotifications.py
+++ b/auctions/management/commands/sendnotifications.py
@@ -22,7 +22,7 @@ class Command(BaseCommand):
                     banned=False, auction=auction
                 )
                 for lot in lots:
-                    self.stdout.write(f" +-\ {lot}")
+                    self.stdout.write(rf" +-\ {lot}")
                     watched = Watch.objects.filter(lot_number=lot.lot_number)
                     for watch in watched:
                         self.stdout.write(f" | +-- {watch}")

--- a/auctions/models.py
+++ b/auctions/models.py
@@ -4285,7 +4285,7 @@ class LotImage(models.Model):
         upload_to="images/",
         blank=False,
         null=False,
-        resize_source=dict(size=(600, 600), quality=85),
+        resize_source={"size": (600, 600), "quality": 85},
     )
     image.help_text = "Select an image to upload"
     image_source = models.CharField(max_length=20, choices=PIC_CATEGORIES, blank=True)

--- a/auctions/models.py
+++ b/auctions/models.py
@@ -89,7 +89,8 @@ def median_value(queryset, term):
 def add_price_info(qs):
     """Add fields `pre_register_discount`, `your_cut` and `club_cut` to a given Lot queryset."""
     if not (isinstance(qs, QuerySet) and qs.model == Lot):
-        raise TypeError("must be passed a queryset of the Lot model")
+        msg = "must be passed a queryset of the Lot model"
+        raise TypeError(msg)
     return qs.annotate(
         pre_register_discount=Case(
             When(auctiontos_seller__isnull=True, then=Value(0.0)),
@@ -214,9 +215,8 @@ def distance_to(
         approximate_distance_to,
     ]:
         if '"' in str(i) or "'" in str(i):
-            raise TypeError(
-                "invalid character passed to distance_to, possible sql injection risk"
-            )
+            msg = "invalid character passed to distance_to, possible sql injection risk"
+            raise TypeError(msg)
     # Great circle distance formula, CEILING is used to keep people from triangulating locations
     gcd_formula = f"CEILING( 6371 * acos(least(greatest( \
         cos(radians({latitude})) * cos(radians({lat_field_name})) \
@@ -242,7 +242,8 @@ def distance_to(
 def add_tos_info(qs):
     """Add fields to a given AuctionTOS queryset."""
     if not (isinstance(qs, QuerySet) and qs.model == AuctionTOS):
-        raise TypeError("must be passed a queryset of the AuctionTOS model")
+        msg = "must be passed a queryset of the AuctionTOS model"
+        raise TypeError(msg)
     return qs.annotate(
         lots_bid_actual=Coalesce(
             Subquery(
@@ -337,7 +338,8 @@ def add_tos_info(qs):
 def add_tos_distance_info(qs):
     """Add a distance_traveled to an auctiontos query"""
     if not (isinstance(qs, QuerySet) and qs.model == AuctionTOS):
-        raise TypeError("must be passed a queryset of the AuctionTOS model")
+        msg = "must be passed a queryset of the AuctionTOS model"
+        raise TypeError(msg)
     return (
         qs.select_related("user__userdata")
         .select_related("pickup_location")
@@ -4260,9 +4262,8 @@ class AuctionCampaign(models.Model):
             if self.user or self.email:
                 duplicate = duplicate.first()
                 if duplicate:
-                    raise ValidationError(
-                        "A campaign with this auction and user/email already exists."
-                    )
+                    msg = "A campaign with this auction and user/email already exists."
+                    raise ValidationError(msg)
         super().save(*args, **kwargs)
 
 

--- a/auctions/models.py
+++ b/auctions/models.py
@@ -189,19 +189,19 @@ def distance_to(
     approximate_distance_to=10,
 ):
     """
-	GeoDjango has been fustrating with MySQL and Point objects.
-	This function is a workaound done using raw SQL.
+    GeoDjango has been fustrating with MySQL and Point objects.
+    This function is a workaound done using raw SQL.
 
-	Given a latitude and longitude, it will return raw SQL that can be used to annotate a queryset
+    Given a latitude and longitude, it will return raw SQL that can be used to annotate a queryset
 
-	The model being annotated must have fields named 'latitude' and 'longitude' for this to work
+    The model being annotated must have fields named 'latitude' and 'longitude' for this to work
 
-	For example:
+    For example:
 
-	qs = model.objects.all()\
-			.annotate(distance=distance_to(latitude, longitude))\
-			.order_by('distance')
-	"""
+    qs = model.objects.all()\
+            .annotate(distance=distance_to(latitude, longitude))\
+            .order_by('distance')
+    """
     if unit == "miles":
         correction = 0.6213712  # close enough
     else:
@@ -219,10 +219,10 @@ def distance_to(
             )
     # Great circle distance formula, CEILING is used to keep people from triangulating locations
     gcd_formula = f"CEILING( 6371 * acos(least(greatest( \
-		cos(radians({latitude})) * cos(radians({lat_field_name})) \
-		* cos(radians({lng_field_name}) - radians({longitude})) + \
-		sin(radians({latitude})) * sin(radians({lat_field_name})) \
-		, -1), 1)) * {correction} / {approximate_distance_to}) * {approximate_distance_to}"
+        cos(radians({latitude})) * cos(radians({lat_field_name})) \
+        * cos(radians({lng_field_name}) - radians({longitude})) + \
+        sin(radians({latitude})) * sin(radians({lat_field_name})) \
+        , -1), 1)) * {correction} / {approximate_distance_to}) * {approximate_distance_to}"
     distance_raw_sql = RawSQL(gcd_formula, ())
     # This one works fine when I print qs.query and run the output in SQL but does not work when Django runs the qs
     # Seems to be an issue with annotating on related entities
@@ -1591,11 +1591,11 @@ class AuctionTOS(models.Model):
                 and self.unprinted_label_count != self.print_labels_qs.count()
             ):
                 result += f"""
-				<button type="button" class="btn btn-sm btn-secondary dropdown-toggle dropdown-toggle-split" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-				</button>
-				<div class="dropdown-menu">
-					<a href='{unprinted_url}'>Print only {self.unprinted_label_count} unprinted labels</a>
-				</div>"""
+                <button type="button" class="btn btn-sm btn-secondary dropdown-toggle dropdown-toggle-split" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                </button>
+                <div class="dropdown-menu">
+                    <a href='{unprinted_url}'>Print only {self.unprinted_label_count} unprinted labels</a>
+                </div>"""
             return html.format_html(result)
         return ""
 
@@ -1707,10 +1707,10 @@ class AuctionTOS(models.Model):
                 dont_use_these = ["13", "14", "15", "16", "17", "18", "19"]
                 search = None
                 if self.phone_number:
-                    search = re.search("([\d]{3}$)|$", self.phone_number).group()
+                    search = re.search(r"([\d]{3}$)|$", self.phone_number).group()
                 if not search or str(search) in dont_use_these:
                     if self.address:
-                        search = re.search("([\d]{3}$)|$", self.address).group()
+                        search = re.search(r"([\d]{3}$)|$", self.address).group()
                 if self.user:
                     userData, created = UserData.objects.get_or_create(
                         user=self.user,

--- a/auctions/models.py
+++ b/auctions/models.py
@@ -379,7 +379,7 @@ def guess_category(text):
     )
     q_objects = Q()
     for keyword in keywords:
-        q_objects |= Q(lot_name__iregex=r"\b{}\b".format(re.escape(keyword)))
+        q_objects |= Q(lot_name__iregex=rf"\b{re.escape(keyword)}\b")
 
     lot_qs = lot_qs.filter(q_objects)
 
@@ -3341,7 +3341,7 @@ class Invoice(models.Model):
             result += "needs to be paid"
         else:
             result += "owes the club"
-        return result + " $" + "%.2f" % self.absolute_amount
+        return result + " $" + f"{self.absolute_amount:.2f}"
 
     @property
     def invoice_summary(self):
@@ -3408,7 +3408,7 @@ class InvoiceAdjustment(models.Model):
 
     @property
     def formatted_float_value(self):
-        return "{:.2f}".format(self.amount)
+        return f"{self.amount:.2f}"
 
     @property
     def display(self):

--- a/auctions/tests.py
+++ b/auctions/tests.py
@@ -836,7 +836,9 @@ class SetLotWinnerViewTest(TestCase):
                 "auction": 5,  # this is not used anywhere, but still required
             },
         )
-        assert response.status_code == 302  # Should redirect after successful form submission
+        assert (
+            response.status_code == 302
+        )  # Should redirect after successful form submission
         updated_lot = Lot.objects.get(pk=self.lot.pk)
         assert updated_lot.auctiontos_winner == self.bidder
         assert updated_lot.winning_price == 100
@@ -957,7 +959,9 @@ class SetLotWinnerViewTest(TestCase):
         )
         assert response.status_code == 200  # Form should not be submitted successfully
         updated_lot = Lot.objects.get(pk=self.lot.pk)
-        assert updated_lot.auctiontos_winner == self.bidder  # Lot winner should remain unchanged
+        assert (
+            updated_lot.auctiontos_winner == self.bidder
+        )  # Lot winner should remain unchanged
         assert updated_lot.winning_price == 100  # Winning price should remain unchanged
 
 

--- a/auctions/tests.py
+++ b/auctions/tests.py
@@ -220,7 +220,7 @@ class AuctionModelTests(TestCase):
             quantity=1,
             description="",
         )
-        self.assertIs(lot.ended, True)
+        assert lot.ended is True
 
     def test_auction_start_and_end(self):
         timeStart = timezone.now() - datetime.timedelta(days=2)
@@ -228,9 +228,9 @@ class AuctionModelTests(TestCase):
         auction = Auction.objects.create(
             title="A test auction", date_end=timeEnd, date_start=timeStart
         )
-        self.assertIs(auction.closed, False)
-        self.assertIs(auction.ending_soon, True)
-        self.assertIs(auction.started, True)
+        assert auction.closed is False
+        assert auction.ending_soon is True
+        assert auction.started is True
 
 
 class LotModelTests(TestCase):
@@ -248,7 +248,7 @@ class LotModelTests(TestCase):
             quantity=1,
             description="",
         )
-        self.assertIs(testLot.ended, False)
+        assert testLot.ended is False
 
     def test_calculated_end_bidding_open(self):
         """
@@ -264,7 +264,7 @@ class LotModelTests(TestCase):
             quantity=1,
             description="",
         )
-        self.assertIs(testLot.ended, True)
+        assert testLot.ended is True
 
     def test_lot_with_no_bids(self):
         time = timezone.now() + datetime.timedelta(days=30)
@@ -276,7 +276,7 @@ class LotModelTests(TestCase):
             user=user,
             description="",
         )
-        self.assertIs(lot.high_bid, 5)
+        assert lot.high_bid == 5
 
     def test_lot_with_one_bids(self):
         time = timezone.now() + datetime.timedelta(days=30)
@@ -291,8 +291,8 @@ class LotModelTests(TestCase):
         )
         user = User.objects.create(username="Test user")
         Bid.objects.create(user=user, lot_number=lot, amount=10)
-        self.assertIs(lot.high_bidder.pk, user.pk)
-        self.assertIs(lot.high_bid, 5)
+        assert lot.high_bidder.pk is user.pk
+        assert lot.high_bid == 5
 
     def test_lot_with_two_bids(self):
         time = timezone.now() + datetime.timedelta(days=30)
@@ -309,8 +309,8 @@ class LotModelTests(TestCase):
         userB = User.objects.create(username="Test user B")
         Bid.objects.create(user=userA, lot_number=lot, amount=10)
         Bid.objects.create(user=userB, lot_number=lot, amount=6)
-        self.assertIs(lot.high_bidder.pk, userA.pk)
-        self.assertIs(lot.high_bid, 7)
+        assert lot.high_bidder.pk is userA.pk
+        assert lot.high_bid == 7
 
     def test_lot_with_two_changing_bids(self):
         time = timezone.now() + datetime.timedelta(days=30)
@@ -326,29 +326,29 @@ class LotModelTests(TestCase):
         jeff = User.objects.create(username="Jeff")
         gary = User.objects.create(username="Gary")
         jeffBid = Bid.objects.create(user=jeff, lot_number=lot, amount=20)
-        self.assertIs(lot.high_bidder.pk, jeff.pk)
-        self.assertIs(lot.high_bid, 20)
+        assert lot.high_bidder.pk is jeff.pk
+        assert lot.high_bid == 20
         garyBid = Bid.objects.create(user=gary, lot_number=lot, amount=20)
-        self.assertIs(lot.high_bidder.pk, jeff.pk)
-        self.assertIs(lot.high_bid, 20)
+        assert lot.high_bidder.pk is jeff.pk
+        assert lot.high_bid == 20
         # check the order
         jeffBid.last_bid_time = timezone.now()
         jeffBid.save()
-        self.assertIs(lot.high_bidder.pk, gary.pk)
-        self.assertIs(lot.high_bid, 20)
+        assert lot.high_bidder.pk is gary.pk
+        assert lot.high_bid == 20
         garyBid.amount = 30
         garyBid.save()
-        self.assertIs(lot.high_bidder.pk, gary.pk)
-        self.assertIs(lot.high_bid, 21)
+        assert lot.high_bidder.pk is gary.pk
+        assert lot.high_bid == 21
         garyBid.last_bid_time = timezone.now()
         garyBid.save()
-        self.assertIs(lot.high_bidder.pk, gary.pk)
-        self.assertIs(lot.high_bid, 21)
+        assert lot.high_bidder.pk is gary.pk
+        assert lot.high_bid == 21
         jeffBid.amount = 30
         jeffBid.last_bid_time = timezone.now()
         jeffBid.save()
-        self.assertIs(lot.high_bidder.pk, gary.pk)
-        self.assertIs(lot.high_bid, 30)
+        assert lot.high_bidder.pk is gary.pk
+        assert lot.high_bid == 30
 
     def test_lot_with_tie_bids(self):
         time = timezone.now() + datetime.timedelta(days=30)
@@ -371,9 +371,9 @@ class LotModelTests(TestCase):
         bidA.save()
         bidB.last_bid_time = tenDaysAgo
         bidB.save()
-        self.assertIs(lot.high_bidder.pk, userB.pk)
-        self.assertIs(lot.high_bid, 6)
-        self.assertIs(lot.max_bid, 6)
+        assert lot.high_bidder.pk is userB.pk
+        assert lot.high_bid == 6
+        assert lot.max_bid == 6
 
     def test_lot_with_three_and_two_tie_bids(self):
         time = timezone.now() + datetime.timedelta(days=30)
@@ -401,9 +401,9 @@ class LotModelTests(TestCase):
         bidB.save()
         bidC.last_bid_time = oneDaysAgo
         bidC.save()
-        self.assertIs(lot.high_bidder.pk, userB.pk)
-        self.assertIs(lot.high_bid, 7)
-        self.assertIs(lot.max_bid, 7)
+        assert lot.high_bidder.pk is userB.pk
+        assert lot.high_bid == 7
+        assert lot.max_bid == 7
 
     def test_lot_with_two_bids_one_after_end(self):
         time = timezone.now() + datetime.timedelta(days=30)
@@ -423,8 +423,8 @@ class LotModelTests(TestCase):
         bidA.last_bid_time = afterEndTime
         bidA.save()
         Bid.objects.create(user=userB, lot_number=lot, amount=6)
-        self.assertIs(lot.high_bidder.pk, userB.pk)
-        self.assertIs(lot.high_bid, 5)
+        assert lot.high_bidder.pk is userB.pk
+        assert lot.high_bid == 5
 
     def test_lot_with_one_bids_below_reserve(self):
         time = timezone.now() + datetime.timedelta(days=30)
@@ -439,8 +439,8 @@ class LotModelTests(TestCase):
         )
         user = User.objects.create(username="Test user")
         Bid.objects.create(user=user, lot_number=lot, amount=2)
-        self.assertIs(lot.high_bidder, False)
-        self.assertIs(lot.high_bid, 5)
+        assert lot.high_bidder is False
+        assert lot.high_bid == 5
 
 
 class ChatSubscriptionTests(TestCase):
@@ -489,7 +489,7 @@ class ChatSubscriptionTests(TestCase):
         sub.save()
         ChatSubscription.objects.create(lot=someone_elses_lot, user=lotuser)
         data = lotuser.userdata
-        self.assertIs(data.unnotified_subscriptions_count, 0)
+        assert data.unnotified_subscriptions_count == 0
         ten_minutes_ago = timezone.now() - datetime.timedelta(minutes=10)
         ten_minutes_in_the_future = timezone.now() + datetime.timedelta(minutes=10)
         twenty_minutes_in_the_future = timezone.now() + datetime.timedelta(minutes=20)
@@ -509,10 +509,10 @@ class ChatSubscriptionTests(TestCase):
         )
         history.timestamp = ten_minutes_ago
         history.save()
-        self.assertIs(data.subscriptions.count(), 3)
-        self.assertIs(data.my_lot_subscriptions_count, 0)
-        self.assertIs(data.other_lot_subscriptions_count, 0)
-        self.assertIs(data.unnotified_subscriptions_count, 0)
+        assert data.subscriptions.count() == 3
+        assert data.my_lot_subscriptions_count == 0
+        assert data.other_lot_subscriptions_count == 0
+        assert data.unnotified_subscriptions_count == 0
         history = LotHistory.objects.create(
             user=chatuser,
             lot=my_lot,
@@ -521,7 +521,7 @@ class ChatSubscriptionTests(TestCase):
         )
         history.timestamp = ten_minutes_in_the_future
         history.save()
-        self.assertIs(data.unnotified_subscriptions_count, 0)
+        assert data.unnotified_subscriptions_count == 0
         history = LotHistory.objects.create(
             user=chatuser,
             lot=my_lot,
@@ -530,7 +530,7 @@ class ChatSubscriptionTests(TestCase):
         )
         history.timestamp = twenty_minutes_in_the_future
         history.save()
-        self.assertIs(data.unnotified_subscriptions_count, 1)
+        assert data.unnotified_subscriptions_count == 1
         history = LotHistory.objects.create(
             user=chatuser,
             lot=someone_elses_lot,
@@ -539,7 +539,7 @@ class ChatSubscriptionTests(TestCase):
         )
         history.timestamp = twenty_minutes_in_the_future
         history.save()
-        self.assertIs(data.other_lot_subscriptions_count, 1)
+        assert data.other_lot_subscriptions_count == 1
         history = LotHistory.objects.create(
             user=chatuser,
             lot=someone_elses_lot,
@@ -564,7 +564,7 @@ class ChatSubscriptionTests(TestCase):
         )
         history.timestamp = twenty_minutes_in_the_future
         history.save()
-        self.assertIs(data.my_lot_subscriptions_count, 1)
+        assert data.my_lot_subscriptions_count == 1
         history = LotHistory.objects.create(
             user=chatuser,
             lot=my_lot_that_is_unsubscribed,
@@ -581,61 +581,59 @@ class ChatSubscriptionTests(TestCase):
         )
         history.timestamp = twenty_minutes_in_the_future
         history.save()
-        self.assertIs(data.my_lot_subscriptions_count, 1)
-        self.assertIs(data.other_lot_subscriptions_count, 1)
+        assert data.my_lot_subscriptions_count == 1
+        assert data.other_lot_subscriptions_count == 1
 
 
 class InvoiceModelTests(StandardTestCase):
     def test_invoices(self):
-        self.assertEqual(self.invoice.auction, self.online_auction)
+        assert self.invoice.auction == self.online_auction
 
-        self.assertEqual(self.invoiceB.flat_value_adjustments, 0)
-        self.assertEqual(self.invoiceB.percent_value_adjustments, 0)
+        assert self.invoiceB.flat_value_adjustments == 0
+        assert self.invoiceB.percent_value_adjustments == 0
 
-        self.assertEqual(self.invoiceB.total_sold, 0)
-        self.assertEqual(self.invoiceB.total_bought, 30)
-        self.assertEqual(self.invoiceB.subtotal, -30)
-        self.assertEqual(self.invoiceB.tax, 7.5)
-        self.assertEqual(self.invoiceB.net, -37.5)
-        self.assertEqual(self.invoiceB.rounded_net, -37)
-        self.assertEqual(self.invoiceB.absolute_amount, 37)
-        self.assertEqual(self.invoiceB.lots_sold, 0)
-        self.assertEqual(self.invoiceB.lots_sold_successfully_count, 0)
-        self.assertEqual(self.invoiceB.unsold_lots, 0)
-        self.assertEqual(self.invoiceB.lots_bought, 3)
+        assert self.invoiceB.total_sold == 0
+        assert self.invoiceB.total_bought == 30
+        assert self.invoiceB.subtotal == -30
+        assert self.invoiceB.tax == 7.5
+        assert self.invoiceB.net == -37.5
+        assert self.invoiceB.rounded_net == -37
+        assert self.invoiceB.absolute_amount == 37
+        assert self.invoiceB.lots_sold == 0
+        assert self.invoiceB.lots_sold_successfully_count == 0
+        assert self.invoiceB.unsold_lots == 0
+        assert self.invoiceB.lots_bought == 3
 
-        self.assertEqual(self.invoice.total_sold, 6.5)
-        self.assertEqual(self.invoice.total_bought, 0)
-        self.assertEqual(self.invoice.subtotal, 6.5)
-        self.assertEqual(self.invoice.tax, 0)
-        self.assertEqual(self.invoice.net, 6.5)
-        self.assertEqual(self.invoice.rounded_net, 7)
-        self.assertEqual(self.invoice.absolute_amount, 7)
-        self.assertEqual(self.invoice.lots_sold, 4)
-        self.assertEqual(self.invoice.lots_sold_successfully_count, 3)
-        self.assertEqual(self.invoice.unsold_lots, 1)
-        self.assertEqual(self.invoice.lots_bought, 0)
-        self.assertEqual(self.invoiceB.location, self.location)
-        self.assertEqual(self.invoiceB.contact_email, "test@example.com")
-        self.assertTrue(self.invoiceB.is_online)
-        self.assertEqual(self.invoiceB.unsold_lot_warning, "")
-        self.assertEqual(
-            str(self.invoice), f"{self.tos.name}'s invoice for {self.tos.auction}"
-        )
+        assert self.invoice.total_sold == 6.5
+        assert self.invoice.total_bought == 0
+        assert self.invoice.subtotal == 6.5
+        assert self.invoice.tax == 0
+        assert self.invoice.net == 6.5
+        assert self.invoice.rounded_net == 7
+        assert self.invoice.absolute_amount == 7
+        assert self.invoice.lots_sold == 4
+        assert self.invoice.lots_sold_successfully_count == 3
+        assert self.invoice.unsold_lots == 1
+        assert self.invoice.lots_bought == 0
+        assert self.invoiceB.location == self.location
+        assert self.invoiceB.contact_email == "test@example.com"
+        assert self.invoiceB.is_online
+        assert self.invoiceB.unsold_lot_warning == ""
+        assert str(self.invoice) == f"{self.tos.name}'s invoice for {self.tos.auction}"
 
         # adjustments
         self.adjustment_add.amount = 0
         self.adjustment_add.save()
-        self.assertEqual(self.invoiceB.net, -27.5)
+        assert self.invoiceB.net == -27.5
         self.adjustment_discount.amount = 0
         self.adjustment_discount.save()
-        self.assertEqual(self.invoiceB.net, -37.5)
+        assert self.invoiceB.net == -37.5
         self.adjustment_add_percent.amount = 0
         self.adjustment_add_percent.save()
-        self.assertEqual(self.invoiceB.net, -34.5)
+        assert self.invoiceB.net == -34.5
         self.adjustment_discount_percent.amount = 0
         self.adjustment_discount_percent.save()
-        self.assertEqual(self.invoiceB.net, -37.5)
+        assert self.invoiceB.net == -37.5
 
 
 class LotPricesTests(TestCase):
@@ -714,44 +712,44 @@ class LotPricesTests(TestCase):
         lots = add_price_info(lots)
 
         lot = lots.filter(pk=self.lot.pk).first()
-        self.assertEqual(lot.your_cut, 5.5)
+        assert lot.your_cut == 5.5
         unsold_lot = lots.filter(pk=self.unsold_lot.pk).first()
-        self.assertEqual(unsold_lot.your_cut, -10)
+        assert unsold_lot.your_cut == -10
         sold_no_auction_lot = lots.filter(pk=self.sold_no_auction_lot.pk).first()
-        self.assertEqual(sold_no_auction_lot.your_cut, 10)
+        assert sold_no_auction_lot.your_cut == 10
         unsold_no_auction_lot = lots.filter(pk=self.unsold_no_auction_lot.pk).first()
-        self.assertEqual(unsold_no_auction_lot.your_cut, 0)
+        assert unsold_no_auction_lot.your_cut == 0
 
         self.auction.winning_bid_percent_to_club = 50
         self.auction.winning_bid_percent_to_club_for_club_members = 0
         self.auction.save()
         lot = lots.filter(pk=self.lot.pk).first()
-        self.assertEqual(lot.your_cut, 3.0)
+        assert lot.your_cut == 3.0
         unsold_lot = lots.filter(pk=self.unsold_lot.pk).first()
-        self.assertEqual(unsold_lot.your_cut, -10)
+        assert unsold_lot.your_cut == -10
 
         self.tos.is_club_member = True
         self.tos.save()
         lot = lots.filter(pk=self.lot.pk).first()
-        self.assertEqual(lot.your_cut, 10)
+        assert lot.your_cut == 10
         # print(lot.winning_price, lot.your_cut)
         unsold_lot = lots.filter(pk=self.unsold_lot.pk).first()
-        self.assertEqual(unsold_lot.your_cut, -10)
+        assert unsold_lot.your_cut == -10
 
         self.auction.winning_bid_percent_to_club_for_club_members = 50
         self.auction.pre_register_lot_discount_percent = 10
         self.auction.save()
         lot = lots.filter(pk=self.lot.pk).first()
-        self.assertEqual(lot.your_cut, 5)
+        assert lot.your_cut == 5
         unsold_lot = lots.filter(pk=self.unsold_lot.pk).first()
-        self.assertEqual(unsold_lot.your_cut, -10)
+        assert unsold_lot.your_cut == -10
 
         self.auction.lot_entry_fee_for_club_members = 1
         self.auction.save()
         lot = lots.filter(pk=self.lot.pk).first()
-        self.assertEqual(lot.your_cut, 4)
+        assert lot.your_cut == 4
         unsold_lot = lots.filter(pk=self.unsold_lot.pk).first()
-        self.assertEqual(unsold_lot.your_cut, -10)
+        assert unsold_lot.your_cut == -10
 
         self.lot.partial_refund_percent = 25
         self.lot.save()
@@ -759,14 +757,14 @@ class LotPricesTests(TestCase):
         self.unsold_lot.save()
 
         lot = lots.filter(pk=self.lot.pk).first()
-        self.assertEqual(lot.your_cut, 3.0)
+        assert lot.your_cut == 3.0
         unsold_lot = lots.filter(pk=self.unsold_lot.pk).first()
-        self.assertEqual(unsold_lot.your_cut, -10)
+        assert unsold_lot.your_cut == -10
 
         self.lot.donation = True
         self.lot.save()
         lot = lots.filter(pk=self.lot.pk).first()
-        self.assertEqual(lot.your_cut, 0)
+        assert lot.your_cut == 0
 
 
 class SetLotWinnerViewTest(TestCase):
@@ -838,17 +836,15 @@ class SetLotWinnerViewTest(TestCase):
                 "auction": 5,  # this is not used anywhere, but still required
             },
         )
-        self.assertEqual(
-            response.status_code, 302
-        )  # Should redirect after successful form submission
+        assert response.status_code == 302  # Should redirect after successful form submission
         updated_lot = Lot.objects.get(pk=self.lot.pk)
-        self.assertEqual(updated_lot.auctiontos_winner, self.bidder)
-        self.assertEqual(updated_lot.winning_price, 100)
+        assert updated_lot.auctiontos_winner == self.bidder
+        assert updated_lot.winning_price == 100
         response = self.client.get(url, {"undo": self.lot.custom_lot_number})
-        self.assertEqual(response.status_code, 200)
+        assert response.status_code == 200
         updated_lot = Lot.objects.get(pk=self.lot.pk)
-        self.assertIsNone(updated_lot.auctiontos_winner)
-        self.assertIsNone(updated_lot.winning_price)
+        assert updated_lot.auctiontos_winner is None
+        assert updated_lot.winning_price is None
 
     def test_invalid_form_submission(self):
         url = reverse("auction_lot_winners_images", kwargs={"slug": self.auction.slug})
@@ -863,12 +859,10 @@ class SetLotWinnerViewTest(TestCase):
                 "auction": 5,
             },
         )
-        self.assertEqual(
-            response.status_code, 200
-        )  # Form should not be submitted successfully
+        assert response.status_code == 200  # Form should not be submitted successfully
         updated_lot = Lot.objects.get(pk=self.lot.pk)
-        self.assertIsNone(updated_lot.auctiontos_winner)
-        self.assertIsNone(updated_lot.winning_price)
+        assert updated_lot.auctiontos_winner is None
+        assert updated_lot.winning_price is None
 
     def test_seller_invoice_closed(self):
         self.invoice = Invoice.objects.get(auctiontos_user=self.seller)
@@ -886,12 +880,10 @@ class SetLotWinnerViewTest(TestCase):
                 "auction": 5,
             },
         )
-        self.assertEqual(
-            response.status_code, 200
-        )  # Form should not be submitted successfully
+        assert response.status_code == 200  # Form should not be submitted successfully
         updated_lot = Lot.objects.get(pk=self.lot.pk)
-        self.assertIsNone(updated_lot.auctiontos_winner)
-        self.assertIsNone(updated_lot.winning_price)
+        assert updated_lot.auctiontos_winner is None
+        assert updated_lot.winning_price is None
 
     def test_winner_invoice_closed(self):
         self.invoice = Invoice.objects.create(auctiontos_user=self.bidder)
@@ -909,12 +901,10 @@ class SetLotWinnerViewTest(TestCase):
                 "auction": 5,
             },
         )
-        self.assertEqual(
-            response.status_code, 200
-        )  # Form should not be submitted successfully
+        assert response.status_code == 200  # Form should not be submitted successfully
         updated_lot = Lot.objects.get(pk=self.lot.pk)
-        self.assertIsNone(updated_lot.auctiontos_winner)
-        self.assertIsNone(updated_lot.winning_price)
+        assert updated_lot.auctiontos_winner is None
+        assert updated_lot.winning_price is None
 
     def test_winner_not_found(self):
         self.client.login(username="testuser", password="testpassword")
@@ -929,12 +919,10 @@ class SetLotWinnerViewTest(TestCase):
                 "auction": 5,
             },
         )
-        self.assertEqual(
-            response.status_code, 200
-        )  # Form should not be submitted successfully
+        assert response.status_code == 200  # Form should not be submitted successfully
         updated_lot = Lot.objects.get(pk=self.lot.pk)
-        self.assertIsNone(updated_lot.auctiontos_winner)
-        self.assertIsNone(updated_lot.winning_price)
+        assert updated_lot.auctiontos_winner is None
+        assert updated_lot.winning_price is None
 
     def test_lot_not_found(self):
         self.client.login(username="testuser", password="testpassword")
@@ -949,9 +937,7 @@ class SetLotWinnerViewTest(TestCase):
                 "auction": 5,
             },
         )
-        self.assertEqual(
-            response.status_code, 200
-        )  # Form should not be submitted successfully
+        assert response.status_code == 200  # Form should not be submitted successfully
 
     def test_lot_already_sold(self):
         self.lot.auctiontos_winner = self.bidder
@@ -969,16 +955,10 @@ class SetLotWinnerViewTest(TestCase):
                 "auction": 5,
             },
         )
-        self.assertEqual(
-            response.status_code, 200
-        )  # Form should not be submitted successfully
+        assert response.status_code == 200  # Form should not be submitted successfully
         updated_lot = Lot.objects.get(pk=self.lot.pk)
-        self.assertEqual(
-            updated_lot.auctiontos_winner, self.bidder
-        )  # Lot winner should remain unchanged
-        self.assertEqual(
-            updated_lot.winning_price, 100
-        )  # Winning price should remain unchanged
+        assert updated_lot.auctiontos_winner == self.bidder  # Lot winner should remain unchanged
+        assert updated_lot.winning_price == 100  # Winning price should remain unchanged
 
 
 class LotRefundDialogTests(TestCase):
@@ -1047,20 +1027,20 @@ class LotRefundDialogTests(TestCase):
         response = self.client.get(
             reverse("lot_refund", kwargs={"pk": self.lot_not_in_auction.pk})
         )
-        self.assertEqual(response.status_code, 404)
+        assert response.status_code == 404
 
     def test_get_lot_refund_dialog(self):
         response = self.client.get(self.lot_url)
-        self.assertEqual(response.status_code, 200)
+        assert response.status_code == 200
         self.assertTemplateUsed(response, "auctions/generic_admin_form.html")
 
     def test_post_lot_refund_dialog(self):
         data = {"partial_refund_percent": 50, "banned": False}
         response = self.client.post(self.lot_url, data)
-        self.assertEqual(response.status_code, 200)
+        assert response.status_code == 200
         self.assertContains(response, "<script>location.reload();</script>")
 
         # Check if the lot was updated
         updated_lot = Lot.objects.get(pk=self.lot.pk)
-        self.assertEqual(updated_lot.partial_refund_percent, 50)
-        self.assertEqual(updated_lot.banned, False)
+        assert updated_lot.partial_refund_percent == 50
+        assert updated_lot.banned is False

--- a/auctions/views.py
+++ b/auctions/views.py
@@ -5631,7 +5631,7 @@ class BlogPostView(DetailView):
         blogpost = self.get_object()
         # this is to allow the chart# syntax
         context["formatted_contents"] = re.sub(
-            r"chart\d", "<canvas id=\g<0>></canvas>", blogpost.body_rendered
+            r"chart\d", r"<canvas id=\g<0>></canvas>", blogpost.body_rendered
         )
         return context
 

--- a/auctions/views.py
+++ b/auctions/views.py
@@ -5279,7 +5279,7 @@ class UserLocationUpdate(UpdateView, SuccessMessageMixin):
         user.save()
         userData.last_activity = timezone.now()
         userData.save()
-        return super(UserLocationUpdate, self).form_valid(form)
+        return super().form_valid(form)
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)

--- a/auctions/views.py
+++ b/auctions/views.py
@@ -174,9 +174,8 @@ def bin_data(
         queryset = queryset.order_by(field_name)
     except:
         if start_bin is None or end_bin is None:
-            raise ValueError(
-                f"queryset cannot be ordered by '{field_name}', so start_bin and end_bin are required"
-            )
+            msg = f"queryset cannot be ordered by '{field_name}', so start_bin and end_bin are required"
+            raise ValueError(msg)
     working_with_date = False
     if queryset.count():
         value = getattr(queryset[0], field_name)
@@ -186,9 +185,8 @@ def bin_data(
             try:
                 float(value)
             except ValueError:
-                raise ValueError(
-                    f"{field_name} needs to be either a datetime or an integer value, got value {value}"
-                )
+                msg = f"{field_name} needs to be either a datetime or an integer value, got value {value}"
+                raise ValueError(msg)
     if start_bin is None:
         start_bin = value
     if end_bin is None:
@@ -272,9 +270,8 @@ class AuctionPermissionsMixin:
         """Helper function used to check and see if request.user is the creator of the auction or is someone who has been made an admin of the auction.
         Returns False on no permission or True if the user has permission to access the auction"""
         if not self.auction:
-            raise Exception(
-                "you must set self.auction (typically in dispatch) for self.is_auction_admin to be available"
-            )
+            msg = "you must set self.auction (typically in dispatch) for self.is_auction_admin to be available"
+            raise Exception(msg)
         result = self.auction.permission_check(self.request.user)
         if not result:
             if self.allow_non_admins:
@@ -296,9 +293,8 @@ class AuctionStatsPermissionsMixin:
         """Helper function used to check and see if request.user is the creator of the auction or is someone who has been made an admin of the auction.
         Returns False on no permission or True if the user has permission to access the auction"""
         if not self.auction:
-            raise Exception(
-                "you must set self.auction (typically in dispatch) for self.is_auction_admin to be available"
-            )
+            msg = "you must set self.auction (typically in dispatch) for self.is_auction_admin to be available"
+            raise Exception(msg)
         result = self.auction.permission_check(self.request.user)
         if not result:
             if not self.auction.make_stats_public:
@@ -1109,7 +1105,8 @@ def feedback(request, pk, leave_as):
         try:
             lot = Lot.objects.get(pk=pk, is_deleted=False)
         except:
-            raise Http404(f"No lot found with key {lot}")
+            msg = f"No lot found with key {lot}"
+            raise Http404(msg)
         winner_checks_pass = False
         seller_checks_pass = False
         if leave_as == "winner":
@@ -1295,7 +1292,8 @@ def invoicePaid(request, pk, **kwargs):
         try:
             invoice = Invoice.objects.get(pk=pk)
         except:
-            raise Http404(f"No invoice found with key {pk}")
+            msg = f"No invoice found with key {pk}"
+            raise Http404(msg)
         checksPass = False
         if invoice.auction:
             if invoice.auction.permission_check(request.user):
@@ -3873,7 +3871,8 @@ class AuctionInfo(FormMixin, DetailView, AuctionPermissionsMixin):
                 self.auction = auction
                 return auction
             except:
-                raise Http404("No auctions found matching the query")
+                msg = "No auctions found matching the query"
+                raise Http404(msg)
 
     def get_success_url(self):
         data = self.request.GET.copy()
@@ -5977,9 +5976,8 @@ class AuctionStatsBarChartJSONView(BaseColumnsHighChartsView, AuctionPermissions
         data = self.get_data()
         providers = self.get_providers()
         if len(data) is not len(providers):
-            raise ValueError(
-                f"self.get_data() return a {len(data)} long array, self.get_providers() returned a {len(providers)} long array.  These need to return the same length array."
-            )
+            msg = f"self.get_data() return a {len(data)} long array, self.get_providers() returned a {len(providers)} long array.  These need to return the same length array."
+            raise ValueError(msg)
         for i, entry in enumerate(data):
             color = tuple(next(color_generator))
             dataset = {
@@ -6604,7 +6602,8 @@ class LotChatSubscribe(View, LoginRequiredMixin):
         except ValueError:
             lot = None
         if not lot:
-            raise Http404(f"No lot found with key {lot}")
+            msg = f"No lot found with key {lot}"
+            raise Http404(msg)
         else:
             subscription, created = ChatSubscription.objects.get_or_create(
                 user=request.user,

--- a/manage.py
+++ b/manage.py
@@ -11,11 +11,12 @@ def main():
     try:
         from django.core.management import execute_from_command_line
     except ImportError as exc:
-        raise ImportError(
+        msg = (
             "Couldn't import Django. Are you sure it's installed and "
             "available on your PYTHONPATH environment variable? Did you "
             "forget to activate a virtual environment?"
-        ) from exc
+        )
+        raise ImportError(msg) from exc
     execute_from_command_line(sys.argv)
 
 

--- a/ruff.toml
+++ b/ruff.toml
@@ -3,7 +3,10 @@ exclude = ["get-pip.py"]
 
 [lint]
 exclude = ["get-pip.py"]
-ignore = ["E722"]
+ignore = [
+    "E501",
+    "E722",
+]
 extend-select = [
     "A",    # flake8-builtins
     # "ARG",  # flake8-unused-arguments
@@ -13,7 +16,7 @@ extend-select = [
     # "D",    # pydocstyle
     # "DJ",   # flake8-django
     # "DTZ",  # flake8-datetimez
-    # "E",    # pycodestyle
+    "E",    # pycodestyle
     "EM",   # flake8-errmsg
     # "ERA",  # eradicate
     "DTZ",  # flake8-datetimez

--- a/ruff.toml
+++ b/ruff.toml
@@ -25,7 +25,7 @@ extend-select = [
     "LOG",  # flake8-logging
     # "N",    # pep8-naming
     # "PL",   # pylint
-    # "PT",   # flake8-pytest-style
+    "PT",   # flake8-pytest-style
     "PTH",  # flake8-use-pathlib
     # "RET",  # flake8-return
     # "RUF",  # ruff-specific rules

--- a/ruff.toml
+++ b/ruff.toml
@@ -14,7 +14,7 @@ extend-select = [
     # "DJ",   # flake8-django
     # "DTZ",  # flake8-datetimez
     # "E",    # pycodestyle
-    # "EM",   # flake8-errmsg
+    "EM",   # flake8-errmsg
     # "ERA",  # eradicate
     "DTZ",  # flake8-datetimez
     "F",    # pyflakes

--- a/ruff.toml
+++ b/ruff.toml
@@ -34,5 +34,5 @@ extend-select = [
     "TID",  # flake8-tidy-imports
     # "T20",  # flake8-print
     "UP",   # pyupgrade
-    # "W",    # pycodestyle warnings
+    "W",    # pycodestyle warnings
 ]

--- a/ruff.toml
+++ b/ruff.toml
@@ -4,4 +4,35 @@ exclude = ["get-pip.py"]
 [lint]
 exclude = ["get-pip.py"]
 ignore = ["E722"]
-extend-select = ["I"]
+extend-select = [
+    "A",    # flake8-builtins
+    # "ARG",  # flake8-unused-arguments
+    # "B",    # flake8-bugbear
+    # "C4",    # flake8-comprehensions
+    # "C90",  # McCabe Complexity
+    # "D",    # pydocstyle
+    # "DJ",   # flake8-django
+    # "DTZ",  # flake8-datetimez
+    # "E",    # pycodestyle
+    # "EM",   # flake8-errmsg
+    # "ERA",  # eradicate
+    "DTZ",  # flake8-datetimez
+    "F",    # pyflakes
+    "FURB", # refurb
+    "G",    # flake8-logging-format
+    "I",    # isort
+    "ICN",  # flake8-import-conventions
+    "LOG",  # flake8-logging
+    # "N",    # pep8-naming
+    # "PL",   # pylint
+    # "PT",   # flake8-pytest-style
+    "PTH",  # flake8-use-pathlib
+    # "RET",  # flake8-return
+    # "RUF",  # ruff-specific rules
+    # "S",    # flake8-bandit
+    # "SIM",  # flake8-simplify
+    "TID",  # flake8-tidy-imports
+    # "T20",  # flake8-print
+    # "UP",   # pyupgrade
+    # "W",    # pycodestyle warnings
+]

--- a/ruff.toml
+++ b/ruff.toml
@@ -33,6 +33,6 @@ extend-select = [
     # "SIM",  # flake8-simplify
     "TID",  # flake8-tidy-imports
     # "T20",  # flake8-print
-    # "UP",   # pyupgrade
+    "UP",   # pyupgrade
     # "W",    # pycodestyle warnings
 ]

--- a/ruff.toml
+++ b/ruff.toml
@@ -11,7 +11,7 @@ extend-select = [
     "A",    # flake8-builtins
     # "ARG",  # flake8-unused-arguments
     # "B",    # flake8-bugbear
-    # "C4",    # flake8-comprehensions
+    "C4",    # flake8-comprehensions
     # "C90",  # McCabe Complexity
     # "D",    # pydocstyle
     # "DJ",   # flake8-django


### PR DESCRIPTION
This is the last significant linting PR that I plan to make. I have a few other ideas for where I might turn next, but will start discussion in an issue.

The first commit introduces a series of additional linting rules that, aspirationally, would be enabled for the project. Rules that passed out of the gate are enabled and the remainder are commented out. Each subsequent commit enables an additional rule and corresponding code changes. There are still a number of rules that are still commented out, but I believe these can be enabled in the future. There were two reasons why I didn't go for enabling all of them now:

1. Some of the lints are easy to enable, but other work should be done before turning them on. Examples include `flake8-print` (disallows print statements; I would like to introduce a logging framework and convert them to logs instead) and `eradicate` (disallows large blocks of commented out code; I don't (yet) have a good enough sense to know what's dead code that should be deleted vs. something else)
1. Some of the lints would be hard to enable right now because resolving them requires making real code changes (more than the superficial changes I've been making so far). 

While some of these lint rules were auto-fixable, the majority were hand edits. If there are lint rules that you either (a) aren't sure are worth enforcing, or (b) seems too risky at this point in time without tests to back us up, let me know and I can drop the corresponding commit for now.