### PR TITLE
Specify python interpreter path in vscode config

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,6 +6,9 @@
     "files.insertFinalNewline": true,
     "files.trimFinalNewlines": true,
     "files.trimTrailingWhitespace": true,
+    "python.analysis.typeCheckingMode": "basic",
+    "python.analysis.autoImportCompletions": true,
+    "python.defaultInterpreterPath": "/usr/local/bin/python",
     "ruff.enable": true,
     "ruff.codeAction.fixViolation": {
         "enable": true


### PR DESCRIPTION
@iragm 

Following up on [your comment](https://github.com/iragm/fishauctions/pull/202#issuecomment-2326847641), it looks like VSCode selected the wrong version of python (there are multiple in the docker container), so it wasn't able to do all of the fancy auto-complete. Setting a default in the VSCode config should fix things. If not, you can also manually tell it to use the proper version of Python:
![image](https://github.com/user-attachments/assets/145474d1-72b7-4bb0-80b9-d82f8a4c6d16)
