### PR TITLE
Potential fix for code scanning alert no. 24: Client-side cross-site scripting

### DIFF
--- a/auctions/templates/base.html
+++ b/auctions/templates/base.html
@@ -430,10 +430,18 @@ window.onload = function() {
       var urlParams = new URLSearchParams(window.location.search);
       var printredirect = urlParams.get('printredirect');
       if (printredirect) {
-        var a = document.createElement("a");
-        a.href = printredirect;
-        document.body.appendChild(a);
-        a.click();
+        // Only allow relative, same-origin links for safety
+        try {
+          var url = new URL(printredirect, window.location.origin);
+          if (url.origin === window.location.origin && url.pathname.startsWith('/')) {
+            var a = document.createElement("a");
+            a.href = url.pathname + url.search + url.hash;
+            document.body.appendChild(a);
+            a.click();
+          }
+        } catch (e) {
+          // Invalid URL, do nothing
+        }
         urlParams.delete('printredirect');
         var newUrl = window.location.pathname + '?' + urlParams.toString();
         window.history.replaceState(null, '', newUrl.endsWith('?') ? window.location.pathname : newUrl);


### PR DESCRIPTION
Potential fix for [https://github.com/iragm/fishauctions/security/code-scanning/24](https://github.com/iragm/fishauctions/security/code-scanning/24)

The safest and most robust fix is to strictly validate or sanitize the `printredirect` parameter before using it as the `href` of the anchor. Ideally, it should only allow safe, same-origin URLs or relative paths, never a `javascript:`, `data:`, or other dangerous scheme. The best default is to disallow all values apart from safe, navigable URLs (such as absolute or relative HTTP/s URLs). For this context, a simple, effective fix is to confirm that the URL begins with `'/'` (ensuring it is a relative path) or is otherwise a safe, same-origin path. Additionally, we can use the browser's URL constructor to check if the constructed URL matches the current origin, and only allow redirection within the application domain.

Changes should be restricted to the region of the script, specifically where `printredirect` is set as a URL (lines 433–434).

**What is needed:**  
- Check that `printredirect` is a valid, safe URL (e.g., parse it with the `URL` constructor and compare origins, or ensure it starts with a relative `/`).
- Only allow setting `a.href` if the check passes; otherwise, do not perform the redirect.
- Potentially escape or encode the value, but whitelisting is safer for this type of link.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
