### PR TITLE
Drop empty auction_site.js and its <script> tags

### DIFF
--- a/auctions/templates/base.html
+++ b/auctions/templates/base.html
@@ -60,7 +60,6 @@ window.onload = function() {
         <script type="text/javascript" src="{% static 'js/vendor/bootstrap.bundle.min.js' %}"></script>
         {# Bootstrap bundle includes Popper.js, no need to load separately #}
         {% endblock %}
-        <script type="text/javascript" src="{% static 'js/auction_site.js' %}"></script>
         {% include 'base_page_view.html' %}
         {% if request.user.is_authenticated %}
         <script>

--- a/auctions/templates/print.html
+++ b/auctions/templates/print.html
@@ -17,7 +17,6 @@
         <meta name="description" content="" />
         <meta name="viewport" content="width=device-width, initial-scale=1" />
         {# Global javascript #}
-        <script type="text/javascript" src="{% static 'js/auction_site.js' %}"></script>
         <script type="text/javascript" src="{% static 'js/vendor/jquery.min.js' %}"></script>
         <script type="text/javascript" src="{% static 'js/vendor/bootstrap.bundle.min.js' %}"></script>
         {# Global stylesheets #}


### PR DESCRIPTION
## Summary

- `auctions/static/js/auction_site.js` is a 0-byte/0-line file that has existed since the initial commit (`9889ddb`). It is referenced as a `<script src>` from `auctions/templates/base.html` (loaded on every page) and `auctions/templates/print.html`.
- Each request fetched a 0-byte JS asset for no reason. Delete the file and remove both `<script>` tags.

## Test plan

- [x] Confirm no other references: `grep -rn 'auction_site.js' auctions/` returns nothing.
- [x] Render any page that extends `base.html` (e.g. lot list) and verify there is no longer a request for `/static/js/auction_site.js` in the DevTools Network panel.
- [x] Render the print view (`print.html`) and confirm the same.
- [x] Existing tests pass.

## Migration impact

None.

## Rollback plan

Revert the commit; re-adds the empty file and the two `<script>` tags. No data or schema impact.
