### PR TITLE
Safer debug flag default value

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,4 @@
-DEBUG='False' # leave unset for development
+DEBUG='True' # set to False or unset in production
 NGINX_IMAGE='lscr.io/linuxserver/swag' # leave unset for development
 NGINX_CONF='./nginx.prod.conf' # leave unset for development
 NGINX_CONF_LOCATION='/config/nginx/site-confs/default.conf' # leave unset for development

--- a/.github/scripts/prepare-ci.sh
+++ b/.github/scripts/prepare-ci.sh
@@ -2,7 +2,9 @@
 
 cp .env.example .env
 
-sed -i "/^DEBUG='False'/d" .env
+# .env.example sets DEBUG='True' for the dev workflow; CI runs in dev mode
+# (it expects EMAIL_BACKEND=console, PAYPAL_API_BASE=sandbox, etc.), so leave
+# the DEBUG line in place. Only strip the production-only nginx settings.
 sed -i "/^NGINX_IMAGE='lscr.io\/linuxserver\/swag'/d" .env
 sed -i "/^NGINX_CONF='.\/nginx.prod.conf'/d" .env
 sed -i "/^NGINX_CONF_LOCATION='\/config\/nginx\/site-confs\/default.conf'/d" .env

--- a/auctions/tests.py
+++ b/auctions/tests.py
@@ -18,6 +18,8 @@ from django.test.client import Client
 from django.urls import reverse
 from django.utils import timezone
 
+from fishauctions._env import parse_bool_env
+
 from .filters import LotAdminFilter
 from .forms import AuctionEditForm, ChangeUsernameForm, CreateLotForm
 from .models import (
@@ -13218,3 +13220,29 @@ class PayPalCSVExportTests(StandardTestCase):
         self.assertIsNotNone(row)
         self.assertLessEqual(len(row[2]), 20)
         self.assertEqual(row[2], "Longfellowtheeloquen")
+
+
+class ParseBoolEnvTests(TestCase):
+    """Cover fishauctions._env.parse_bool_env, which gates settings.DEBUG."""
+
+    def test_unset_returns_default(self) -> None:
+        self.assertTrue(parse_bool_env(None, default=True))
+        self.assertFalse(parse_bool_env(None, default=False))
+
+    def test_truthy_spellings(self) -> None:
+        for value in ("1", "true", "True", "TRUE", "yes", "on", "t", "y", "  true  "):
+            with self.subTest(value=value):
+                self.assertTrue(parse_bool_env(value, default=False))
+
+    def test_falsy_spellings(self) -> None:
+        # "False" is the legacy spelling in .env.example; "false" was the
+        # previously-broken case under the old `== "False"` check.
+        # "   " covers the whitespace-only path documented in _env.py.
+        for value in ("0", "false", "False", "FALSE", "no", "off", "f", "n", "", "   "):
+            with self.subTest(value=value):
+                self.assertFalse(parse_bool_env(value, default=True))
+
+    def test_unrecognized_value_raises(self) -> None:
+        # A typo in the env value must fail loudly, not silently default.
+        with self.assertRaises(ValueError):
+            parse_bool_env("maybe", default=False)

--- a/fishauctions/_env.py
+++ b/fishauctions/_env.py
@@ -1,0 +1,31 @@
+"""Helpers for parsing environment variables in settings.
+
+Kept in its own module (instead of inline in settings.py) so it can be
+unit-tested without importing the full Django settings module.
+"""
+
+_TRUTHY = frozenset({"1", "true", "yes", "on", "t", "y"})
+_FALSY = frozenset({"0", "false", "no", "off", "f", "n", ""})
+
+
+def parse_bool_env(value: str | None, *, default: bool) -> bool:
+    """Parse a string env-var value into a bool, case-insensitively.
+
+    - ``None`` (env var not set) returns ``default``.
+    - Leading/trailing whitespace is stripped before matching, so a
+      whitespace-only value (e.g. ``"   "``) normalizes to ``""`` and is
+      treated as falsy.
+    - Recognized truthy: 1, true, yes, on, t, y (any case).
+    - Recognized falsy: 0, false, no, off, f, n, empty string (any case).
+    - Anything else raises ``ValueError`` so a typo in the env var doesn't
+      silently degrade to a wrong default.
+    """
+    if value is None:
+        return default
+    normalized = value.strip().lower()
+    if normalized in _TRUTHY:
+        return True
+    if normalized in _FALSY:
+        return False
+    msg = f"Cannot parse {value!r} as a boolean env value"
+    raise ValueError(msg)

--- a/fishauctions/settings.py
+++ b/fishauctions/settings.py
@@ -30,8 +30,12 @@ ADMINS = [("Admin", os.environ.get("ADMIN_EMAIL", "admin@example.com"))]
 SECRET_KEY = os.environ.get("SECRET_KEY", "unsecure")
 
 # SECURITY WARNING: don't run with debug turned on in production!
-# Unset DEBUG defaults to True per `.env.example` ("leave unset for development").
-DEBUG = parse_bool_env(os.environ.get("DEBUG"), default=True)
+# Default fail-closed: unset DEBUG => False. Dev environments must opt in
+# explicitly with DEBUG=true (see .env.example and docker-compose.yaml).
+# This protects against an env-var misconfiguration in production silently
+# leaving debug on, which also flips EMAIL_BACKEND, PAYPAL_API_BASE, and
+# SQUARE_ENVIRONMENT to non-production paths.
+DEBUG = parse_bool_env(os.environ.get("DEBUG"), default=False)
 
 # Template string for undefined variables - empty string means silently ignore them
 TEMPLATE_STRING_IF_INVALID = ""

--- a/fishauctions/settings.py
+++ b/fishauctions/settings.py
@@ -15,6 +15,8 @@ import os
 from decimal import Decimal
 from pathlib import Path
 
+from fishauctions._env import parse_bool_env
+
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve(strict=True).parent.parent
 
@@ -28,10 +30,8 @@ ADMINS = [("Admin", os.environ.get("ADMIN_EMAIL", "admin@example.com"))]
 SECRET_KEY = os.environ.get("SECRET_KEY", "unsecure")
 
 # SECURITY WARNING: don't run with debug turned on in production!
-if os.environ.get("DEBUG", "1") == "False":
-    DEBUG = False
-else:
-    DEBUG = True
+# Unset DEBUG defaults to True per `.env.example` ("leave unset for development").
+DEBUG = parse_bool_env(os.environ.get("DEBUG"), default=True)
 
 # Template string for undefined variables - empty string means silently ignore them
 TEMPLATE_STRING_IF_INVALID = ""

--- a/readme.md
+++ b/readme.md
@@ -39,6 +39,8 @@ docker compose up -d
 ```
 You should now be able to access a development site at 127.0.0.1 (Note: unlike most Django projects, you probably won't use port 8000)
 
+**`DEBUG` is fail-closed**: an unset `DEBUG` env var resolves to `False` (production mode). The `.env.example` sets `DEBUG='True'` so a fresh dev setup works out of the box. If you have an existing `.env` from before this change, add `DEBUG='True'` (or `DEBUG=1`) to keep dev mode; otherwise the app will start in production mode and route real email, hit the live PayPal API, etc.
+
 **Demo data**: In development mode (DEBUG=True), the system will automatically load demo data including 3 sample auctions, users, lots, and bids when starting with an empty database. This provides realistic examples to explore the application's features.
 
 One last thing to do is to create an admin.  Back in the shell, enter:


### PR DESCRIPTION
The previous logic to parse the debug flag only disabled debug for the exact string "False". A common typo ("false", "0", "no") would silently leave debug on in production. This PR makes two primary changes:

1. Default to setting debug to false unless otherwise specified to prevent accidental misconfigurations in production
2. Move boolean parsing into `fishauctions/_env.py::parse_bool_env`:
    * Case-insensitive recognition of common truthy spellings (1, true, yes, on, t, y) and falsy spellings (0, false, no, off, f, n, empty string).
    * Leading/trailing whitespace is stripped before matching, so a whitespace-only value normalizes to "" and is treated as falsy.
    * Unrecognized values raise ValueError so a typo fails loudly at startup rather than silently picking the wrong default.
    * A keyword-only `default` covers the "env var not set" case so each call site decides what unset means.