### PR TITLE
Fail fast on insecure secrets in production

### DIFF
--- a/auctions/tests.py
+++ b/auctions/tests.py
@@ -10,7 +10,7 @@ from unittest.mock import patch
 
 from django import forms
 from django.contrib.auth.models import User
-from django.core.exceptions import ValidationError
+from django.core.exceptions import ImproperlyConfigured, ValidationError
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.core.management import call_command
 from django.test import TestCase, TransactionTestCase, override_settings
@@ -18,7 +18,7 @@ from django.test.client import Client
 from django.urls import reverse
 from django.utils import timezone
 
-from fishauctions._env import parse_bool_env
+from fishauctions._env import parse_bool_env, require_secure_prod_secrets
 
 from .filters import LotAdminFilter
 from .forms import AuctionEditForm, ChangeUsernameForm, CreateLotForm
@@ -9205,8 +9205,6 @@ class SquareWebhookSignatureValidationTests(StandardTestCase):
 
     def test_improperly_configured_in_production_without_webhook_key(self):
         """Test that ImproperlyConfigured is raised in production when Square is configured but webhook key is missing"""
-        from django.core.exceptions import ImproperlyConfigured
-
         url = reverse("square_webhook")
 
         # Simulate production mode (DEBUG=False) with Square configured but no webhook signature key
@@ -13246,3 +13244,39 @@ class ParseBoolEnvTests(TestCase):
         # A typo in the env value must fail loudly, not silently default.
         with self.assertRaises(ValueError):
             parse_bool_env("maybe", default=False)
+
+
+class RequireSecureProdSecretsTests(TestCase):
+    """Cover fishauctions._env.require_secure_prod_secrets."""
+
+    def test_all_secrets_set_passes(self) -> None:
+        require_secure_prod_secrets(
+            {
+                "SECRET_KEY": "a-real-secret-value",
+                "DATABASE_PASSWORD": "real-db-pw",
+                "REDIS_PASSWORD": "real-redis-pw",
+            }
+        )
+
+    def test_each_insecure_value_raises(self) -> None:
+        # None covers "env var unset"; "" and "unsecure" are the literal
+        # placeholders shipped in settings.py and docker-compose.yaml.
+        for value in (None, "", "unsecure"):
+            with self.subTest(value=value):
+                with self.assertRaises(ImproperlyConfigured) as ctx:
+                    require_secure_prod_secrets({"SECRET_KEY": value})
+                self.assertIn("SECRET_KEY", str(ctx.exception))
+
+    def test_multiple_offenders_reported_together(self) -> None:
+        with self.assertRaises(ImproperlyConfigured) as ctx:
+            require_secure_prod_secrets(
+                {
+                    "SECRET_KEY": "unsecure",
+                    "DATABASE_PASSWORD": None,
+                    "REDIS_PASSWORD": "real-redis-pw",
+                }
+            )
+        message = str(ctx.exception)
+        self.assertIn("SECRET_KEY", message)
+        self.assertIn("DATABASE_PASSWORD", message)
+        self.assertNotIn("REDIS_PASSWORD", message)

--- a/fishauctions/_env.py
+++ b/fishauctions/_env.py
@@ -4,8 +4,14 @@ Kept in its own module (instead of inline in settings.py) so it can be
 unit-tested without importing the full Django settings module.
 """
 
+from collections.abc import Mapping
+
+from django.core.exceptions import ImproperlyConfigured
+
 _TRUTHY = frozenset({"1", "true", "yes", "on", "t", "y"})
 _FALSY = frozenset({"0", "false", "no", "off", "f", "n", ""})
+
+INSECURE_SECRET_VALUES = frozenset({"", "unsecure"})
 
 
 def parse_bool_env(value: str | None, *, default: bool) -> bool:
@@ -29,3 +35,24 @@ def parse_bool_env(value: str | None, *, default: bool) -> bool:
         return False
     msg = f"Cannot parse {value!r} as a boolean env value"
     raise ValueError(msg)
+
+
+def require_secure_prod_secrets(secrets: Mapping[str, str | None]) -> None:
+    """Raise ``ImproperlyConfigured`` if any secret is unset or has a known-insecure default.
+
+    Intended to be called from ``settings.py`` only when ``DEBUG`` is False.
+    A value is considered insecure if it is ``None`` or in
+    ``INSECURE_SECRET_VALUES`` (the literal placeholders shipped as defaults
+    in this codebase). Every offender is reported in a single error message
+    so the operator sees the full picture in one startup pass.
+    """
+    bad = sorted(name for name, value in secrets.items() if value is None or value in INSECURE_SECRET_VALUES)
+    if not bad:
+        return
+    joined = ", ".join(bad)
+    msg = (
+        f"The following environment variables are unset or set to a known-insecure "
+        f"default but are required when DEBUG=False: {joined}. Set each one to a "
+        f"secure value before starting the application in production."
+    )
+    raise ImproperlyConfigured(msg)

--- a/fishauctions/settings.py
+++ b/fishauctions/settings.py
@@ -15,7 +15,7 @@ import os
 from decimal import Decimal
 from pathlib import Path
 
-from fishauctions._env import parse_bool_env
+from fishauctions._env import parse_bool_env, require_secure_prod_secrets
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve(strict=True).parent.parent
@@ -36,6 +36,19 @@ SECRET_KEY = os.environ.get("SECRET_KEY", "unsecure")
 # leaving debug on, which also flips EMAIL_BACKEND, PAYPAL_API_BASE, and
 # SQUARE_ENVIRONMENT to non-production paths.
 DEBUG = parse_bool_env(os.environ.get("DEBUG"), default=False)
+
+# Fail fast on insecure defaults in production. The validated set is
+# intentionally narrow: feature-conditional secrets (PAYPAL_*, SQUARE_*,
+# AWS_*, RECAPTCHA_*) fail visibly at use time and forcing them at
+# startup would block deploys that don't use those features.
+if not DEBUG:
+    require_secure_prod_secrets(
+        {
+            "SECRET_KEY": SECRET_KEY,
+            "DATABASE_PASSWORD": os.environ.get("DATABASE_PASSWORD"),
+            "REDIS_PASSWORD": os.environ.get("REDIS_PASSWORD"),
+        }
+    )
 
 # Template string for undefined variables - empty string means silently ignore them
 TEMPLATE_STRING_IF_INVALID = ""


### PR DESCRIPTION
When DEBUG=False, validate that the security-critical environment variables are not unset and not still set to the literal "unsecure" default that ships in settings.py and docker-compose.yaml. The previous behavior was that a missed env var in production would become SECRET_KEY="unsecure" / DATABASE_PASSWORD="unsecure" / etc.

Note that this PR is stacked on top of https://github.com/iragm/fishauctions/pull/811, so the other PR should be reviewed/merged first.

Add require_secure_prod_secrets(secrets) in fishauctions/_env.py. It takes a mapping of name -> value, checks each against the module-level INSECURE_SECRET_VALUES sentinel ({"", "unsecure"}), and raises ImproperlyConfigured with every bad name listed in a single error message so the operator sees the full picture in one startup pass rather than fixing one variable at a time.

settings.py invokes the validator after DEBUG is computed, gated on if not DEBUG:. The validated set is intentionally narrow: SECRET_KEY, DATABASE_PASSWORD, REDIS_PASSWORD. Feature-conditional secrets (PAYPAL_, SQUARE_, AWS_, RECAPTCHA_) fail visibly at use time and forcing them at startup would block deploys that don't use those features. FIELD_ENCRYPTION_KEY already has its own auto-generation / print-help fail-loud logic further down in settings.py and is left alone here.

Tests in auctions/tests.py::RequireSecureProdSecretsTests cover the all-good path, the three insecure-value cases (None / "" / "unsecure") via subTest matching the established ParseBoolEnvTests style, and the multi-offender single-message contract.

While here, remove a redundant inline from django.core.exceptions import ImproperlyConfigured at tests.py:9208 -- the module-top import added by this commit makes it unnecessary.

Note: python manage.py check --deploy still emits warnings for ALLOWED_HOSTS, SECURE_SSL_REDIRECT, SECURE_HSTS_*, and the secure-cookie flags. Those are owned by other tracked items in the backlog (ALLOWED_HOSTS hardening; secure cookies + proxy SSL header) and are deliberately not addressed here.