### PR TITLE
Restrict test-DB grant to test_% databases

### DIFF
--- a/db-init/01-grant-test-permissions.sql
+++ b/db-init/01-grant-test-permissions.sql
@@ -1,17 +1,14 @@
--- Grant permissions for the test database
--- Django's test runner creates test databases with a 'test_' prefix
--- This grants the database user permission to create and use test databases
+-- Grant permissions for the test database.
+-- Django's test runner creates databases with a 'test_' prefix
+-- (test_<dbname> for serial runs; test_<dbname>_1..N for --parallel).
+-- This file is executed only on first-time MariaDB volume initialization.
+--
+-- ALL PRIVILEGES at database scope already includes CREATE and DROP, so a
+-- single pattern-scoped grant covers everything Django needs while keeping
+-- the test user out of every other database on the server. (Verified
+-- against MariaDB 12.2 -- earlier comments here claimed CREATE/DROP could
+-- only be granted globally on `*.*`; that is not the case on the version
+-- we ship.)
 
--- Note: CREATE and DROP privileges must be granted globally (on *.*) in MariaDB as it doesn't
--- support database name patterns for these grants. This allows Django to create and drop
--- test databases with any name (e.g., test_auctions, test_auctions_2 for parallel tests)
-
--- Check if user already has these privileges, if not grant them
--- This makes the script idempotent for existing dev systems with persistent volumes
-GRANT CREATE, DROP ON *.* TO 'mysqluser'@'%';
-
--- Grant full privileges on any database starting with 'test_'
--- This pattern matching is supported for table-level privileges in MariaDB
-GRANT ALL PRIVILEGES ON `test_%`.* TO 'mysqluser'@'%';
-
+GRANT ALL PRIVILEGES ON `test\_%`.* TO 'mysqluser'@'%';
 FLUSH PRIVILEGES;

--- a/db-init/01-grant-test-permissions.sql
+++ b/db-init/01-grant-test-permissions.sql
@@ -5,10 +5,6 @@
 --
 -- ALL PRIVILEGES at database scope already includes CREATE and DROP, so a
 -- single pattern-scoped grant covers everything Django needs while keeping
--- the test user out of every other database on the server. (Verified
--- against MariaDB 12.2 -- earlier comments here claimed CREATE/DROP could
--- only be granted globally on `*.*`; that is not the case on the version
--- we ship.)
+-- the test user out of every other database on the server.
 
 GRANT ALL PRIVILEGES ON `test\_%`.* TO 'mysqluser'@'%';
-FLUSH PRIVILEGES;

--- a/docs/testing-with-mariadb.md
+++ b/docs/testing-with-mariadb.md
@@ -29,10 +29,9 @@ If you're upgrading from a previous version and have an existing MariaDB volume,
 ./grant-test-permissions.sh
 
 # Option 2: Apply the same change manually
-docker exec -it db mariadb -uroot -p${DATABASE_ROOT_PASSWORD} -e "
+docker exec -it db mariadb -uroot -p"${DATABASE_ROOT_PASSWORD}" -e "
 REVOKE CREATE, DROP ON *.* FROM 'mysqluser'@'%';
-GRANT ALL PRIVILEGES ON \`test_%\`.* TO 'mysqluser'@'%';
-FLUSH PRIVILEGES;
+GRANT ALL PRIVILEGES ON \`test\_%\`.* TO 'mysqluser'@'%';
 "
 ```
 

--- a/docs/testing-with-mariadb.md
+++ b/docs/testing-with-mariadb.md
@@ -20,19 +20,23 @@ Tests now run against a MariaDB database instead of SQLite to better match the p
 
 ## Upgrading Existing Development Systems
 
-If you're upgrading from a previous version and have an existing MariaDB volume, you may need to manually grant test database permissions:
+If you're upgrading from a previous version and have an existing MariaDB volume, you may need to manually grant test database permissions. (The init scripts in `db-init/` only run on first volume initialization, so changes to them do not apply to existing volumes.)
 
 ```bash
-# Option 1: Run the helper script from the repo root
+# Option 1: Run the helper script from the repo root. It detects and revokes
+#          any prior over-broad CREATE/DROP grant on *.* before applying the
+#          tightened pattern-scoped grant on test_%.* — safe to re-run.
 ./grant-test-permissions.sh
 
-# Option 2: Grant permissions manually
+# Option 2: Apply the same change manually
 docker exec -it db mariadb -uroot -p${DATABASE_ROOT_PASSWORD} -e "
-GRANT CREATE, DROP ON *.* TO 'mysqluser'@'%';
+REVOKE CREATE, DROP ON *.* FROM 'mysqluser'@'%';
 GRANT ALL PRIVILEGES ON \`test_%\`.* TO 'mysqluser'@'%';
 FLUSH PRIVILEGES;
 "
 ```
+
+The pattern-scoped grant restricts the test user to creating and dropping databases whose names start with `test_` (e.g. `test_auctions`, `test_auctions_1`...`test_auctions_N` for `--parallel`). They cannot create or drop any other database on the server, including the production `auctions` database.
 
 ## Running Tests
 
@@ -53,7 +57,7 @@ docker exec -it django python3 manage.py test --verbosity=2
 ## Requirements
 
 - The database container must be running and healthy (`docker compose up -d`)
-- The database user must have CREATE and DROP privileges (automatically configured via `db-init/01-grant-test-permissions.sql`)
+- The database user must have privileges on the `test_%` database name pattern (automatically configured via `db-init/01-grant-test-permissions.sql` on first volume initialization)
 
 ## Continuous Integration
 

--- a/grant-test-permissions.sh
+++ b/grant-test-permissions.sh
@@ -13,24 +13,30 @@
 set -euo pipefail
 
 ROOT_PW="${DATABASE_ROOT_PASSWORD:-secret}"
+DB_USER="${DATABASE_USER:-mysqluser}"
 
 run_sql() {
     docker exec -i db mariadb -uroot -p"${ROOT_PW}" -e "$1"
 }
 
-echo "Inspecting current grants for mysqluser..."
-GRANTS="$(docker exec -i db mariadb -uroot -p"${ROOT_PW}" -BNe \
-    "SHOW GRANTS FOR 'mysqluser'@'%'" 2>/dev/null || true)"
+# MariaDB returns ERROR 1141 only when the user has no grant entry at all for
+# the scope; tolerate that case so the script is idempotent on already-
+# tightened systems. Any other error propagates.
+tolerate_no_such_grant() {
+    local stderr_file rc
+    stderr_file="$(mktemp)"
+    trap 'rm -f "${stderr_file}"' RETURN
+    if docker exec -i db mariadb -uroot -p"${ROOT_PW}" -e "$1" 2>"${stderr_file}"; then
+        return 0
+    fi
+    rc=$?
+    if grep -q "ERROR 1141" "${stderr_file}"; then
+        return 0
+    fi
+    cat "${stderr_file}" >&2
+    return "${rc}"
+}
 
-if echo "${GRANTS}" | grep -qE 'GRANT [A-Z, ]*(CREATE|DROP)[A-Z, ]* ON \*\.\*'; then
-    echo "Found over-broad CREATE/DROP grant on *.*; revoking..."
-    run_sql "REVOKE CREATE, DROP ON *.* FROM 'mysqluser'@'%';"
-fi
-
-echo "Granting pattern-scoped permissions on test_%.* ..."
-run_sql "GRANT ALL PRIVILEGES ON \`test\\_%\`.* TO 'mysqluser'@'%'; FLUSH PRIVILEGES;"
-
-echo "Final grants:"
-run_sql "SHOW GRANTS FOR 'mysqluser'@'%';"
-
+tolerate_no_such_grant "REVOKE CREATE, DROP ON *.* FROM '${DB_USER}'@'%';"
+run_sql "GRANT ALL PRIVILEGES ON \`test\\_%\`.* TO '${DB_USER}'@'%';"
 echo "✓ Permissions updated"

--- a/grant-test-permissions.sh
+++ b/grant-test-permissions.sh
@@ -1,18 +1,36 @@
 #!/bin/bash
-# Script to grant test database permissions on existing development systems
-# Run this if you're getting "Access denied for user 'mysqluser'@'%' to database 'test_auctions'"
-# For fresh installations, 01-grant-test-permissions.sql handles this automatically.
+# Apply test-database permissions to an existing development MariaDB volume.
+#
+# Fresh installations get the right grants from db-init/01-grant-test-permissions.sql
+# on first volume initialization. Run this script if you upgraded an existing
+# dev volume that was provisioned by an older version of that init SQL (which
+# granted CREATE/DROP on *.*) -- it tightens the grant down to test_%.* and
+# revokes the over-broad prior grant if present.
+#
+# Symptom that means you need to run this:
+#   "Access denied for user 'mysqluser'@'%' to database 'test_auctions'"
 
-echo "Granting test database permissions to mysqluser..."
-docker exec -i db mariadb -uroot -p"${DATABASE_ROOT_PASSWORD:-secret}" -e "
-GRANT CREATE, DROP ON *.* TO 'mysqluser'@'%';
-GRANT ALL PRIVILEGES ON \`test_%\`.* TO 'mysqluser'@'%';
-FLUSH PRIVILEGES;
-"
+set -euo pipefail
 
-if [ $? -eq 0 ]; then
-    echo "✓ Permissions granted successfully"
-else
-    echo "✗ Failed to grant permissions. Make sure the db container is running and DATABASE_ROOT_PASSWORD is correct."
-    exit 1
+ROOT_PW="${DATABASE_ROOT_PASSWORD:-secret}"
+
+run_sql() {
+    docker exec -i db mariadb -uroot -p"${ROOT_PW}" -e "$1"
+}
+
+echo "Inspecting current grants for mysqluser..."
+GRANTS="$(docker exec -i db mariadb -uroot -p"${ROOT_PW}" -BNe \
+    "SHOW GRANTS FOR 'mysqluser'@'%'" 2>/dev/null || true)"
+
+if echo "${GRANTS}" | grep -qE 'GRANT [A-Z, ]*(CREATE|DROP)[A-Z, ]* ON \*\.\*'; then
+    echo "Found over-broad CREATE/DROP grant on *.*; revoking..."
+    run_sql "REVOKE CREATE, DROP ON *.* FROM 'mysqluser'@'%';"
 fi
+
+echo "Granting pattern-scoped permissions on test_%.* ..."
+run_sql "GRANT ALL PRIVILEGES ON \`test\\_%\`.* TO 'mysqluser'@'%'; FLUSH PRIVILEGES;"
+
+echo "Final grants:"
+run_sql "SHOW GRANTS FOR 'mysqluser'@'%';"
+
+echo "✓ Permissions updated"


### PR DESCRIPTION
The mysqluser test account was granted CREATE, DROP ON *.* — i.e. it could create or drop *any* database on the server, not just Django's test_<name> databases. The grant file's inline comment documenting that MariaDB does not support pattern-scoped CREATE/DROP, only table-level pattern grants, no longer applies to the version of MariaDB we ship (verified empirically against mariadb:latest (12.2.2-MariaDB-ubu2404))

```sql
GRANT ALL PRIVILEGES ON `test\_%`.* TO 'mysqluser'@'%';
```

is sufficient. ALL at database scope already includes CREATE and DROP, so a single pattern-scoped grant covers everything Django's test runner needs (test_<name> for serial, test_<name>_1..N for --parallel) while denying any operation on databases outside the test_% prefix

