### PR TITLE
more debugging info for lost bids

### DIFF
--- a/auctions/consumers.py
+++ b/auctions/consumers.py
@@ -430,12 +430,21 @@ class LotConsumer(WebsocketConsumer):
             self.user_room_name = f"private_user_{self.user.pk}_lot_{self.lot_number}"
             self.lot = Lot.objects.get(pk=self.lot_number)
 
+            # TEMP lifecycle logging to diagnose silently-dropped bids (remove once resolved)
+            logger.info(
+                "WS connect lot=%s user_pk=%s authed=%s",
+                self.lot_number,
+                self.user.pk,
+                self.user.is_authenticated,
+            )
+
             # Join room group
             async_to_sync(self.channel_layer.group_add)(self.room_group_name, self.channel_name)
 
             # Join private room for notifications only to this user
             async_to_sync(self.channel_layer.group_add)(self.user_room_name, self.channel_name)
             self.accept()
+            logger.info("WS accepted lot=%s user_pk=%s", self.lot_number, self.user.pk)
             # send the most recent history
             allHistory = LotHistory.objects.filter(lot=self.lot, removed=False).order_by("-timestamp")[:200]
             # send oldest first
@@ -505,9 +514,18 @@ class LotConsumer(WebsocketConsumer):
                     existing_subscription.last_notification_sent = timezone.now()
                     existing_subscription.save()
         except Exception as e:
-            logger.exception(e)
+            # TEMP lifecycle logging (remove once resolved): a failure here may mean the socket
+            # was never accepted, so the client silently can't bid.
+            logger.exception("WS connect FAILED lot=%s: %s", getattr(self, "lot_number", "?"), e)
 
     def disconnect(self, close_code):
+        # TEMP lifecycle logging to diagnose silently-dropped bids (remove once resolved)
+        logger.info(
+            "WS disconnect lot=%s user_pk=%s close_code=%s",
+            getattr(self, "lot_number", "?"),
+            getattr(getattr(self, "user", None), "pk", None),
+            close_code,
+        )
         # Leave room group
         async_to_sync(self.channel_layer.group_discard)(self.room_group_name, self.channel_name)
         # bit redundant, but 'seen' is used for lot notifications for the owner of a given lot
@@ -531,6 +549,15 @@ class LotConsumer(WebsocketConsumer):
     # Receive message from WebSocket
     def receive(self, text_data):
         text_data_json = json.loads(text_data)
+        # TEMP lifecycle logging to diagnose silently-dropped bids (remove once resolved)
+        if "bid" in text_data_json:
+            logger.info(
+                "WS bid received lot=%s user_pk=%s authed=%s amount=%s",
+                getattr(self, "lot_number", "?"),
+                getattr(getattr(self, "user", None), "pk", None),
+                self.user.is_authenticated,
+                text_data_json.get("bid"),
+            )
         if self.user.is_authenticated:
             try:
                 error = check_all_permissions(self.lot, self.user)
@@ -626,7 +653,13 @@ class LotConsumer(WebsocketConsumer):
             except Exception as e:
                 logger.exception(e)
         else:
-            pass
+            # TEMP lifecycle logging (remove once resolved): the socket authed as anonymous,
+            # so anything sent here (including bids) is silently discarded.
+            logger.info(
+                "WS message from UNAUTHENTICATED socket dropped lot=%s keys=%s",
+                getattr(self, "lot_number", "?"),
+                list(text_data_json.keys()),
+            )
 
     # Send a toast error to a single user
     def error_message(self, event):

--- a/auctions/templates/view_lot_images.html
+++ b/auctions/templates/view_lot_images.html
@@ -541,9 +541,11 @@ function deactivate_lot() {
                                         {% endif %}
                                         $('#confirmDialogText').html(dialogText);
                                         document.querySelector('#finalize-bid').onclick = function(e) {
-                                            lotWebSocket.send(JSON.stringify({
-                                                'bid': bid
-                                            }));
+                                            if (!lotWebSocketSend({ 'bid': bid })) {
+                                                // Socket was down: don't fake a confirmation, the bid was not placed.
+                                                $('#confirmBid').modal('hide');
+                                                return;
+                                            }
                                             var your_bid = Number($('#your_bid_price').html());
                                             var price = Number($('#price').html());
                                             if (bid > your_bid) {
@@ -748,13 +750,16 @@ function deactivate_lot() {
         {% endif %}
         var viewer_bid = '{{ lot.viewer_bid }}';
         var ws_protocol = (window.location.protocol === 'https:') ? 'wss://' : 'ws://'
-        const lotWebSocket = new WebSocket(
-            ws_protocol
-            + window.location.host
-            + '/ws/lots/{{ lot.lot_number }}/'
-        );
+        var lotWebSocketUrl = ws_protocol + window.location.host + '/ws/lots/{{ lot.lot_number }}/';
+        // A WebSocket can be closed at any time by idle proxy timeouts, network blips, or a
+        // server restart.  send() on a closed socket is *silently discarded* by the browser
+        // (no error thrown), so without reconnect logic a dropped connection makes every
+        // later bid/chat vanish with no feedback until a full page reload.  Use let + a
+        // reconnect helper instead of a one-shot const so the page can heal itself.
+        var lotWebSocket = null;
+        var lotWebSocketReconnectDelay = 1000;
 
-        lotWebSocket.onmessage = function(e) {
+        function handleLotSocketMessage(e) {
             const data = JSON.parse(e.data);
             if (data.current_high_bid) {
                 $("#price").html(data.current_high_bid);
@@ -855,18 +860,42 @@ function deactivate_lot() {
             }
             showLatestChat();
         }
-        // lotWebSocket.onclose = function(e) {
-        //     var errorHtml = '<span class="mr-1 mt-1 text-danger">Connection lost</span>\
-        //     <input id="reconnect_button" onclick="window.location.reload(true);"\
-        //     type="button" class="col-md-2 mr-1 mt-1 btn-sm btn-danger" value="Reconnect"><br>';
-        //     $('#send_chat_area').html(errorHtml);
-        //     $('#bid_area').html(errorHtml);
-        //     $.toast({
-        //         title: 'Connection lost',
-        //         type: 'error',
-        //         delay: 10000
-        //     });
-        // };
+        function connectLotWebSocket() {
+            lotWebSocket = new WebSocket(lotWebSocketUrl);
+            lotWebSocket.onmessage = handleLotSocketMessage;
+            lotWebSocket.onopen = function() {
+                lotWebSocketReconnectDelay = 1000;
+            };
+            lotWebSocket.onclose = function() {
+                // Reconnect with backoff so the page heals itself instead of silently
+                // dropping every future bid into a dead socket.
+                setTimeout(connectLotWebSocket, lotWebSocketReconnectDelay);
+                lotWebSocketReconnectDelay = Math.min(lotWebSocketReconnectDelay * 2, 15000);
+            };
+            lotWebSocket.onerror = function() {
+                try { lotWebSocket.close(); } catch (err) {}
+            };
+        }
+        connectLotWebSocket();
+
+        // Only send when the socket is actually open.  Returns true if the message was
+        // handed to an open socket, or false (and warns the user + kicks off a reconnect)
+        // when the socket is down -- so callers can avoid showing a false confirmation.
+        function lotWebSocketSend(payload) {
+            if (lotWebSocket && lotWebSocket.readyState === WebSocket.OPEN) {
+                lotWebSocket.send(JSON.stringify(payload));
+                return true;
+            }
+            if (!lotWebSocket || lotWebSocket.readyState === WebSocket.CLOSED) {
+                connectLotWebSocket();
+            }
+            $.toast({
+                title: 'Connection dropped, so that did not go through. Reconnecting now -- please try again in a moment.',
+                type: 'warning',
+                delay: 8000
+            });
+            return false;
+        }
 
         function showLatestChat() {
             var objDiv = document.getElementById("chat");
@@ -882,9 +911,7 @@ function deactivate_lot() {
             const messageInputDom = document.querySelector('#chat_input');
             const message = messageInputDom.value;
             if (message) {
-                lotWebSocket.send(JSON.stringify({
-                    'message': message
-                }));
+                lotWebSocketSend({ 'message': message });
             }
             messageInputDom.value = '';
             {% if show_chat_subscriptions_checkbox %}

--- a/auctions/templates/view_lot_images.html
+++ b/auctions/templates/view_lot_images.html
@@ -861,6 +861,11 @@ function deactivate_lot() {
             showLatestChat();
         }
         function connectLotWebSocket() {
+            // Don't stack duplicate sockets: a close can trigger both a scheduled reconnect
+            // and an on-demand reconnect from lotWebSocketSend().  Bail if one is already live.
+            if (lotWebSocket && (lotWebSocket.readyState === WebSocket.CONNECTING || lotWebSocket.readyState === WebSocket.OPEN)) {
+                return;
+            }
             lotWebSocket = new WebSocket(lotWebSocketUrl);
             lotWebSocket.onmessage = handleLotSocketMessage;
             lotWebSocket.onopen = function() {

--- a/nginx_fishauctions.conf
+++ b/nginx_fishauctions.conf
@@ -10,6 +10,13 @@
         proxy_set_header Connection "upgrade";
         client_max_body_size 20M;
 
+        # WebSocket connections (/ws/) are long-lived and mostly idle.  nginx's default
+        # proxy_read_timeout is 60s, which would silently close an idle lot-page socket.
+        # Keep them open for an hour.  (This also applies to plain HTTP here, which is fine
+        # -- the app server has its own request timeouts.)
+        proxy_read_timeout 3600s;
+        proxy_send_timeout 3600s;
+
         # Don't add cross-origin headers here - let Django middleware handle them selectively
         # This allows YouTube embeds to work on pages that don't need WebAssembly
         # Only pages with voice recognition (set-winners) get strict COEP headers from Django


### PR DESCRIPTION
Problem: in-person auctions w/ online bidding — bids intermittently fail silently (no error, no confirmation, usually no Bid row), "refresh fixes it," <10s after load, in-person-specific.

Confirmed

Bid logic is correct (reproduced bid_on_lot: proxy auto-bump + raise-max persistence work). Not a logic bug.
Frontend sends {'bid': N} correctly.
On failure: send() ran without throwing and no DB row → socket was not OPEN (closed, or open-but-anonymous).
Prod logs at failure: redis.exceptions.TimeoutError: Timeout reading from redis:6379 via a CancelledError → TimeoutError cascade + repeated accept/close cycles.
Ruled out (with evidence) — don't re-investigate these:

nginx 60s idle timeout — fails at <10s, not 60s.
Resource exhaustion — prod workers 20–27 fds / limit 1024; redis 44/10000 clients, 2.3 MB; MariaDB max_connections=10000; 5-day uptime, flat fds = no leak.
"5s BZPOPMIN socket race" — reproduced locally: idle channel receive blocks cleanly 13s past the 5s brpop_timeout; socket_timeout=None.
Feb-27 multi-bid refactor and club changes — consumers.py + nginx identical to master; logic works.
Still open — the actual root cause of why connections drop/fail intermittently. The redis Timeout reading is most likely redis-py mislabeling an interrupted read during teardown (CancelledError is innermost) — a symptom, not necessarily the cause. The temp logging splits it into: (a) transport (connect fails before accept), (b) auth (anonymous socket), or (c) genuine redis stall.

Relevant facts: channels_redis 4.3.0 / redis-py 7.4.0 / Django 5.2.14; RedisChannelLayer BRPOP-based, no socket_keepalive/health_check_interval/retry_on_timeout; CONN_MAX_AGE=0; gunicorn -w 8; disconnect() leaks user_room_name (bounded by 24h expiry). The latent client bug (master, years old): const lotWebSocket, onclose/onerror commented out, no reconnect, no readyState guard → a closed socket silently eats bids. That's the symptom amplifier; the drop cause is what's left to find.

Branch fix-lot-websocket-reconnect (from master, uncommitted):

view_lot_images.html — reconnect + backoff + readyState-guarded send + no false confirmation (fixes the silent-drop symptom for the "closed socket" case).
nginx_fishauctions.conf — proxy_read_timeout/proxy_send_timeout 3600s (hygiene).
consumers.py — temp lifecycle logging (marked "remove once resolved").
Next phase: deploy → reproduce one failed bid → docker logs django | grep "WS " → read the decision tree (no WS bid received = transport; authed=False/UNAUTHENTICATED dropped = auth; authed=True + no row = logic). In parallel: prod redis-cli --latency-history / SLOWLOG GET / INFO persistence. Candidate fix if it's channel-layer fragility: RedisPubSubChannelLayer + connection resilience — confirm cause first.

Saved all of this to memory (inperson-online-bid-silent-drop) so it carries into the next session.